### PR TITLE
Process Sockaddr Info Item during ConnectionManager::forwardOpen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Features**:
 
 * add Identity Object #5, @flipback
-* add utils::LogAppender to customise logging #5, @flipback
+* add utils::LogAppenderIf to customise logging #5, @flipback
 
 # Release 1.0.0 (2019-12-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * add Identity Object #5, @flipback
 * add utils::LogAppenderIf to customise logging #5, @flipback
 
+**Bugs**:
+
+* fix implicit messaging on OSX and check connection sizes #10, @flipback
+
 # Release 1.0.0 (2019-12-08)
 
 Initial release

--- a/docker/gdbserver/Dockerfile
+++ b/docker/gdbserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/spreenauten/lm-dev/lm-preprocessor/preprocessor-deps:latest
+FROM gcc:8
 
 RUN apt-get update && apt-get install -y \
     openssh-server gdb gdbserver rsync

--- a/examples/ExplicitAndImplicitMessagingExample.cpp
+++ b/examples/ExplicitAndImplicitMessagingExample.cpp
@@ -81,6 +81,7 @@ int main() {
 	parameters.o2tNetworkConnectionParams |= NetworkConnectionParams::SCHEDULED_PRIORITY;
 	parameters.o2tNetworkConnectionParams |= 32; //size of Assm150 = 32
 
+	parameters.originatorSerialNumber = 0x12345;
 	parameters.o2tRPI = 1000000;
 	parameters.t2oRPI = 1000000;
 	parameters.transportTypeTrigger |= NetworkConnectionParams::CLASS1;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCE_FILES
         fileObject/FileObjectUploadInProgressState.cpp
 
         sockets/BaseSocket.cpp
+        sockets/EndPoint.cpp
         sockets/TCPSocket.cpp
         sockets/UDPBoundSocket.cpp
         sockets/UDPSocket.cpp

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -95,9 +95,9 @@ namespace eipScanner {
 			ioConnection->_connectionPath = connectionParameters.connectionPath;
 			ioConnection->_originatorVendorId = connectionParameters.originatorVendorId;
 			ioConnection->_originatorSerialNumber = connectionParameters.originatorSerialNumber;
-			ioConnection->_socket = std::make_unique<UDPSocket>(si->getRemoteEndPoint());
+			ioConnection->_socket = std::make_unique<UDPSocket>(si->getRemoteEndPoint().getHost(), 2222);
 
-			findOrCreateSocket(si->getRemoteEndPoint());
+			findOrCreateSocket(sockets::EndPoint(si->getRemoteEndPoint().getHost(), 2222));
 
 			auto result = _connectionMap
 					.insert(std::make_pair(response.getT2ONetworkConnectionId(), ioConnection));

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -33,7 +33,7 @@ namespace eipScanner {
 	ConnectionManager::~ConnectionManager() = default;
 
 	IOConnection::WPtr
-	ConnectionManager::forwardOpen(SessionInfo::SPtr si, ConnectionParameters connectionParameters) {
+	ConnectionManager::forwardOpen(SessionInfoIf::SPtr si, ConnectionParameters connectionParameters) {
 		static int serialNumberCount = 0;
 		connectionParameters.connectionSerialNumber = ++serialNumberCount;
 
@@ -111,7 +111,7 @@ namespace eipScanner {
 		return ioConnection;
 	}
 
-	void ConnectionManager::forwardClose(SessionInfo::SPtr si, const IOConnection::WPtr& ioConnection) {
+	void ConnectionManager::forwardClose(SessionInfoIf::SPtr si, const IOConnection::WPtr& ioConnection) {
 		if (auto ptr = ioConnection.lock()) {
 			ForwardCloseRequest request;
 
@@ -189,14 +189,14 @@ namespace eipScanner {
 				commonPacket.expand(recvData);
 
 				// TODO: Check TypeIDs and sequnce of the packages
-				Buffer buffer(commonPacket[0].getData());
+				Buffer buffer(commonPacket.getItems().at(0).getData());
 				cip::CipUdint connectionId;
 				buffer >> connectionId;
 				Logger(LogLevel::DEBUG) << "Received data from connection T2O_ID=" << connectionId;
 
 				auto io = _connectionMap.find(connectionId);
 				if (io != _connectionMap.end()) {
-					io->second->notifyReceiveData(commonPacket[1].getData());
+					io->second->notifyReceiveData(commonPacket.getItems().at(1).getData());
 				} else {
 					Logger(LogLevel::ERROR) << "Received data from unknow connection T2O_ID=" << connectionId;
 				}

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -2,7 +2,9 @@
 // Created by Aleksey Timin on 11/18/19.
 //
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
+#include <cstdlib>
+#include <random>
 
 #include "ConnectionManager.h"
 #include "eip/CommonPacket.h"
@@ -28,6 +30,10 @@ namespace eipScanner {
 		: _messageRouter(std::move(messageRouter))
 		, _connectionMap()
 		, _lastHandleTime(std::chrono::steady_clock::now()){
+
+		std::random_device rd;
+		std::uniform_int_distribution<cip::CipUint> dist(0, std::numeric_limits<cip::CipUint>::max());
+		_incarnationId = dist(rd);
 	}
 
 	ConnectionManager::~ConnectionManager() = default;
@@ -39,14 +45,13 @@ namespace eipScanner {
 
 		if ((connectionParameters.o2tNetworkConnectionParams
 			& NetworkConnectionParams::MULTICAST) > 0) {
-			static cip::CipUint idCount = 0;
-			connectionParameters.o2tNetworkConnectionId = connectionParameters.originatorSerialNumber << 16;
+			static cip::CipUint idCount = _incarnationId << 16;
 			connectionParameters.o2tNetworkConnectionId = ++idCount;
 		}
 
 		if ((connectionParameters.t2oNetworkConnectionParams
 			 & NetworkConnectionParams::P2P) > 0) {
-			static cip::CipUdint idCount = 0;
+			static cip::CipUdint idCount = _incarnationId << 16;
 			connectionParameters.t2oNetworkConnectionId = ++idCount;
 		}
 

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -55,6 +55,9 @@ namespace eipScanner {
 			connectionParameters.t2oNetworkConnectionId = ++idCount;
 		}
 
+		auto o2tSize = connectionParameters.o2tNetworkConnectionParams & 0x1ff;
+		auto t2oSize = connectionParameters.t2oNetworkConnectionParams & 0x1ff;
+
 		connectionParameters.connectionPathSize =  (connectionParameters.connectionPath .size() / 2)
 				+ (connectionParameters.connectionPath .size() % 2);
 
@@ -103,6 +106,13 @@ namespace eipScanner {
 			ioConnection->_connectionPath = connectionParameters.connectionPath;
 			ioConnection->_originatorVendorId = connectionParameters.originatorVendorId;
 			ioConnection->_originatorSerialNumber = connectionParameters.originatorSerialNumber;
+
+			ioConnection->_o2tDataSize = o2tSize;
+			ioConnection->_t2oDataSize = t2oSize;
+			ioConnection->_o2tFixedSize = (connectionParameters.o2tNetworkConnectionParams
+						& NetworkConnectionParams::VARIABLE) == 0;
+			ioConnection->_t2oFixedSize = (connectionParameters.t2oNetworkConnectionParams
+						& NetworkConnectionParams::VARIABLE) == 0;
 
 			const eip::CommonPacketItem::Vec &additionalItems = messageRouterResponse.getAdditionalPacketItems();
 			auto o2tSockAddrInfo = std::find_if(additionalItems.begin(), additionalItems.end(),
@@ -215,7 +225,7 @@ namespace eipScanner {
 				CommonPacket commonPacket;
 				commonPacket.expand(recvData);
 
-				// TODO: Check TypeIDs and sequnce of the packages
+				// TODO: Check TypeIDs and sequence of the packages
 				Buffer buffer(commonPacket.getItems().at(0).getData());
 				cip::CipUdint connectionId;
 				buffer >> connectionId;

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -124,6 +124,9 @@ namespace eipScanner {
 				ioConnection->_socket = std::make_unique<UDPSocket>(si->getRemoteEndPoint().getHost(), 2222);	
 			}
 
+			Logger(LogLevel::INFO) << "Open UDP socket to send data to "
+					<< ioConnection->_socket->getRemoteEndPoint().toString();
+
 			findOrCreateSocket(sockets::EndPoint(si->getRemoteEndPoint().getHost(), 2222));
 
 			auto result = _connectionMap

--- a/src/ConnectionManager.h
+++ b/src/ConnectionManager.h
@@ -41,6 +41,7 @@ namespace eipScanner {
 
 		sockets::UDPBoundSocket::SPtr  findOrCreateSocket(const sockets::EndPoint& endPoint);
 		std::chrono::steady_clock::time_point _lastHandleTime;
+		cip::CipUint _incarnationId;
 	};
 }
 

--- a/src/ConnectionManager.h
+++ b/src/ConnectionManager.h
@@ -15,16 +15,6 @@
 
 namespace eipScanner {
 
-	struct SocketKey {
-		std::string host;
-		int port;
-
-		inline bool operator< (const SocketKey& rhs) const {
-			return host < rhs.host
-				&& port < rhs.port;
-		}
-	};
-
 	enum class ConnectionManagerServiceCodes : cip::CipUsint {
 		FORWARD_OPEN = 0x54,
 		FORWARD_CLOSE = 0x4E
@@ -47,9 +37,9 @@ namespace eipScanner {
 	private:
 		MessageRouter::SPtr _messageRouter;
 		std::map<cip::CipUint, IOConnection::SPtr> _connectionMap;
-		std::map<SocketKey, std::shared_ptr<sockets::UDPBoundSocket>> _socketMap;
+		std::map<sockets::EndPoint, std::shared_ptr<sockets::UDPBoundSocket>> _socketMap;
 
-		sockets::UDPBoundSocket::SPtr  findOrCreateSocket(const std::string& host, int port);
+		sockets::UDPBoundSocket::SPtr  findOrCreateSocket(const sockets::EndPoint& endPoint);
 		std::chrono::steady_clock::time_point _lastHandleTime;
 	};
 }

--- a/src/ConnectionManager.h
+++ b/src/ConnectionManager.h
@@ -35,8 +35,8 @@ namespace eipScanner {
 		explicit ConnectionManager(MessageRouter::SPtr messageRouter);
 		~ConnectionManager();
 
-		IOConnection::WPtr forwardOpen(SessionInfo::SPtr si, cip::connectionManager::ConnectionParameters connectionParameters);
-		void forwardClose(SessionInfo::SPtr si, const IOConnection::WPtr& ioConnection);
+		IOConnection::WPtr forwardOpen(SessionInfoIf::SPtr si, cip::connectionManager::ConnectionParameters connectionParameters);
+		void forwardClose(SessionInfoIf::SPtr si, const IOConnection::WPtr& ioConnection);
 
 		/**
 		 * Handles active connections

--- a/src/FileObject.cpp
+++ b/src/FileObject.cpp
@@ -15,7 +15,7 @@ namespace eipScanner {
 
 
 
-	FileObject::FileObject(cip::CipUint instanceId, SessionInfo::SPtr si, MessageRouter::SPtr messageRouter)
+	FileObject::FileObject(cip::CipUint instanceId, SessionInfoIf::SPtr si, MessageRouter::SPtr messageRouter)
 		: BaseObject(fileObject::FILE_OBJECT_CLASS_ID, instanceId)
 		, _state(new fileObject::FileObjectState(FileObjectStateCodes::UNKNOWN, *this, instanceId, messageRouter)) {
 		_state->SyncState(si);
@@ -27,11 +27,11 @@ namespace eipScanner {
 		return _state;
 	}
 
-	void FileObject::beginUpload(SessionInfo::SPtr si, fileObject::EndUploadHandler handle) {
+	void FileObject::beginUpload(SessionInfoIf::SPtr si, fileObject::EndUploadHandler handle) {
 		_state->initiateUpload(si, handle);
 	}
 
-	bool FileObject::handleTransfers(SessionInfo::SPtr si) {
+	bool FileObject::handleTransfers(SessionInfoIf::SPtr si) {
 		return _state->transfer(si);
 	}
 }

--- a/src/FileObject.h
+++ b/src/FileObject.h
@@ -52,16 +52,16 @@ namespace eipScanner {
 	public:
 		using UPtr = std::unique_ptr<FileObject>;
 		
-		FileObject(cip::CipUint instanceId, SessionInfo::SPtr si, MessageRouter::SPtr messageRouter);
+		FileObject(cip::CipUint instanceId, SessionInfoIf::SPtr si, MessageRouter::SPtr messageRouter);
 		~FileObject();
 		std::unique_ptr<fileObject::FileObjectState>&  getState();
-		void beginUpload(SessionInfo::SPtr si, fileObject::EndUploadHandler handle);
+		void beginUpload(SessionInfoIf::SPtr si, fileObject::EndUploadHandler handle);
 
 		/**
 		 * handle active download/upload transfers
 		 * @return true if downloading/uploading is in progress
 		 */
-		bool handleTransfers(SessionInfo::SPtr si);
+		bool handleTransfers(SessionInfoIf::SPtr si);
 
 
 	private:

--- a/src/IOConnection.cpp
+++ b/src/IOConnection.cpp
@@ -94,7 +94,7 @@ namespace eipScanner {
 			Buffer buffer;
 			if ((_transportTypeTrigger & NetworkConnectionParams::CLASS1) > 0
 				|| (_transportTypeTrigger & NetworkConnectionParams::CLASS3) > 0) {
-				buffer << _sequenceValueCount++;
+				buffer << ++_sequenceValueCount;
 			}
 
 			if (_o2tRealTimeFormat) {

--- a/src/IOConnection.cpp
+++ b/src/IOConnection.cpp
@@ -22,6 +22,10 @@ namespace eipScanner {
 			, _t2oNetworkConnectionId{0}
 			, _o2tAPI{0}
 			, _t2oAPI{0}
+			, _o2tDataSize{0}
+			, _t2oDataSize{0}
+			, _o2tFixedSize(true)
+			, _t2oFixedSize(true)
 			, _o2tTimer{0}
 			, _t2o_timer{0}
 			, _connectionTimeoutMultiplier{0}
@@ -56,7 +60,6 @@ namespace eipScanner {
 	}
 
 	void IOConnection::notifyReceiveData(const std::vector<uint8_t> &data) {
-		_connectionTimeoutCount = 0;
 		Buffer buffer(data);
 		cip::CipUdint runtimeHeader = 0;
 		cip::CipUint sequenceValueCount = 0;
@@ -70,9 +73,16 @@ namespace eipScanner {
 			buffer >> sequenceValueCount;
 		}
 
-
-		_receiveDataHandle(runtimeHeader, sequenceValueCount,
-				std::vector<uint8_t>(data.begin() + buffer.pos(), data.end()));
+		std::vector<uint8_t> ioData(data.begin() + buffer.pos(), data.end());
+		if (_t2oFixedSize && ioData.size() != _t2oDataSize) {
+			Logger(LogLevel::WARNING) << "Connection T2O_ID=" << _t2oNetworkConnectionId
+				<< " has fixed size " << _t2oDataSize << " bytes but " << ioData.size()
+				<< " bytes were received. Ignore this data.";
+		} else {
+			_connectionTimeoutCount = 0;
+			_receiveDataHandle(runtimeHeader, sequenceValueCount,
+							   ioData);
+		}
 	}
 
 	bool IOConnection::notifyTick(std::chrono::milliseconds period) {
@@ -102,11 +112,17 @@ namespace eipScanner {
 				buffer << header;
 			}
 
-			buffer << _outputData;
-			commonPacket << factory.createConnectedDataItem(buffer.data());
-
-			_socket->Send(commonPacket.pack());
 			_o2tTimer = 0;
+			if (_o2tFixedSize && _outputData.size() != _o2tDataSize)  {
+				Logger(LogLevel::WARNING) << "Connection O2T_ID=" << _o2tNetworkConnectionId
+										  << " has fixed size " << _o2tDataSize << " bytes but " << _outputData.size()
+										  << " bytes are to send. Don't send this data.";
+			} else {
+				buffer << _outputData;
+				commonPacket << factory.createConnectedDataItem(buffer.data());
+
+				_socket->Send(commonPacket.pack());
+			}
 		}
 
 		return true;

--- a/src/IOConnection.h
+++ b/src/IOConnection.h
@@ -39,6 +39,12 @@ namespace eipScanner {
 		cip::CipUdint _o2tAPI;
 		cip::CipUdint _t2oAPI;
 
+		size_t _o2tDataSize;
+		size_t _t2oDataSize;
+
+		bool _o2tFixedSize;
+		bool _t2oFixedSize;
+
 		cip::CipUdint _o2tTimer;
 		cip::CipUdint _t2o_timer;
 

--- a/src/IdentityObject.cpp
+++ b/src/IdentityObject.cpp
@@ -20,11 +20,11 @@ namespace eipScanner {
 		, _productName("") {
 	}
 
-	IdentityObject::IdentityObject(cip::CipUint instanceId, const SessionInfo::SPtr &si)
+	IdentityObject::IdentityObject(cip::CipUint instanceId, const SessionInfoIf::SPtr &si)
 		: IdentityObject(instanceId, si, std::make_shared<MessageRouter>()){
 	}
 
-	IdentityObject::IdentityObject(cip::CipUint instanceId, const SessionInfo::SPtr &si, const MessageRouter::SPtr &messageRouter)
+	IdentityObject::IdentityObject(cip::CipUint instanceId, const SessionInfoIf::SPtr &si, const MessageRouter::SPtr &messageRouter)
 		: BaseObject(CLASS_ID, instanceId) {
 
 		auto response = messageRouter->sendRequest(

--- a/src/IdentityObject.h
+++ b/src/IdentityObject.h
@@ -17,8 +17,8 @@ namespace eipScanner {
 	public:
 		static const cip::CipUint CLASS_ID = 0x01;
 		IdentityObject(cip::CipUint instanceId);
-		IdentityObject(cip::CipUint instanceId, const SessionInfo::SPtr& si);
-		IdentityObject(cip::CipUint instanceId, const SessionInfo::SPtr& si, const MessageRouter::SPtr& messageRouter);
+		IdentityObject(cip::CipUint instanceId, const SessionInfoIf::SPtr& si);
+		IdentityObject(cip::CipUint instanceId, const SessionInfoIf::SPtr& si, const MessageRouter::SPtr& messageRouter);
 
 		cip::CipUint getVendorId() const;
 		cip::CipUint getDeviceType() const;

--- a/src/MessageRouter.cpp
+++ b/src/MessageRouter.cpp
@@ -18,6 +18,7 @@ namespace eipScanner {
 	using namespace utils;
 	using eip::CommonPacketItemFactory;
 	using eip::CommonPacket;
+	using eip::CommonPacketItem;
 	using eip::EncapsPacket;
 	using eip::EncapsPacketFactory;
 
@@ -26,12 +27,19 @@ namespace eipScanner {
 	MessageRouter::~MessageRouter() = default;
 
 	MessageRouterResponse
-	MessageRouter::sendRequest(SessionInfo::SPtr si, CipUsint service, const EPath &path,
+	MessageRouter::sendRequest(SessionInfoIf::SPtr si, CipUsint service, const EPath &path,
 							   const std::vector<uint8_t> &data) const {
+		return this->sendRequest(si, service, path, data, {});
+	}
+
+	MessageRouterResponse
+	MessageRouter::sendRequest(SessionInfoIf::SPtr si, CipUsint service, const EPath &path,
+							   const std::vector<uint8_t> &data,
+							   const std::vector<eip::CommonPacketItem>& additionalPacketItems) const {
 		assert(si);
 
 		Logger(LogLevel::INFO) << "Send request: service=0x" << std::hex << static_cast<int>(service)
-			<< " epath=" << path.toString();
+							   << " epath=" << path.toString();
 
 		MessageRouterRequest request{service, path, data};
 
@@ -39,6 +47,10 @@ namespace eipScanner {
 		CommonPacket commonPacket;
 		commonPacket << commonPacketItemFactory.createNullAddressItem();
 		commonPacket << commonPacketItemFactory.createUnconnectedDataItem(request.pack());
+
+		for(auto& item : additionalPacketItems) {
+			commonPacket << item;
+		}
 
 		auto packetToSend = EncapsPacketFactory()
 				.createSendRRDataPacket(si->getSessionHandle(), 0, commonPacket.pack());
@@ -51,12 +63,23 @@ namespace eipScanner {
 		std::vector<uint8_t> receivedData(receivedPacket.getData().size() - 6);
 
 		buffer >> interfaceHandle >> timeout >> receivedData;
-
 		commonPacket.expand(receivedData);
 
 		MessageRouterResponse response;
-		response.expand(commonPacket[1].getData());
+		const CommonPacketItem::Vec &items = commonPacket.getItems();
+
+		response.expand(items.at(1).getData());
+		if (items.size() > 2) {
+			response.setAdditionalPacketItems(
+					CommonPacketItem::Vec(items.begin() + 2, items.end()));
+		}
+
 
 		return response;
+	}
+
+	MessageRouterResponse
+	MessageRouter::sendRequest(SessionInfoIf::SPtr si, CipUsint service, const EPath &path) const {
+		return this->sendRequest(si, service, path, {}, {});
 	}
 }

--- a/src/MessageRouter.h
+++ b/src/MessageRouter.h
@@ -9,6 +9,7 @@
 #include "cip/EPath.h"
 #include "cip/Services.h"
 #include "cip/MessageRouterResponse.h"
+#include "eip/CommonPacketItem.h"
 #include "SessionInfo.h"
 
 namespace eipScanner {
@@ -18,8 +19,15 @@ namespace eipScanner {
 
 		MessageRouter();
 		virtual ~MessageRouter();
-		virtual cip::MessageRouterResponse sendRequest(SessionInfo::SPtr si, cip::CipUsint service,
+		virtual cip::MessageRouterResponse sendRequest(SessionInfoIf::SPtr si, cip::CipUsint service,
+				const cip::EPath& path, const std::vector<uint8_t>& data,
+				const std::vector<eip::CommonPacketItem>& additionalPacketItems) const;
+
+		virtual cip::MessageRouterResponse sendRequest(SessionInfoIf::SPtr si, cip::CipUsint service,
 				const cip::EPath& path, const std::vector<uint8_t>& data) const;
+
+		virtual cip::MessageRouterResponse sendRequest(SessionInfoIf::SPtr si, cip::CipUsint service,
+													   const cip::EPath& path) const;
 
 	};
 }

--- a/src/ParameterObject.cpp
+++ b/src/ParameterObject.cpp
@@ -35,7 +35,7 @@ namespace eipScanner {
 	};
 
 	ParameterObject::ParameterObject(cip::CipUint id, bool fullAttributes,
-									 const SessionInfo::SPtr &si)
+									 const SessionInfoIf::SPtr &si)
 		: ParameterObject(id, fullAttributes, si, std::make_shared<MessageRouter>()) {
 	}
 
@@ -54,7 +54,7 @@ namespace eipScanner {
 	}
 
 	ParameterObject::ParameterObject(cip::CipUint instanceId, bool fullAttributes,
-			const SessionInfo::SPtr &si,
+			const SessionInfoIf::SPtr &si,
 			const MessageRouter::SPtr& messageRouter)
 		:  BaseObject(CLASS_ID, instanceId)
 		, _name{""}
@@ -160,7 +160,7 @@ namespace eipScanner {
 		}
 	}
 
-	void ParameterObject::updateValue(const SessionInfo::SPtr& si) {
+	void ParameterObject::updateValue(const SessionInfoIf::SPtr& si) {
 		auto response = _messageRouter->sendRequest(si,
 								ServiceCodes::GET_ATTRIBUTE_SINGLE,
 								EPath(CLASS_ID, getInstanceId(),

--- a/src/ParameterObject.h
+++ b/src/ParameterObject.h
@@ -33,9 +33,9 @@ public:
 	 * @param fullAttributes if true, then read all the attributes
 	 * @param si
 	 */
-	ParameterObject(cip::CipUint instanceId, bool fullAttributes, const SessionInfo::SPtr& si);
+	ParameterObject(cip::CipUint instanceId, bool fullAttributes, const SessionInfoIf::SPtr& si);
 
-	ParameterObject(cip::CipUint instanceId, bool fullAttributes, const SessionInfo::SPtr& si, const MessageRouter::SPtr&);
+	ParameterObject(cip::CipUint instanceId, bool fullAttributes, const SessionInfoIf::SPtr& si, const MessageRouter::SPtr&);
 
 	/**
 	 * Create an empty instance without any EIP requests
@@ -51,7 +51,7 @@ public:
 	 * Updates value from the instance
 	 * @param si
 	 */
-	void updateValue(const SessionInfo::SPtr& si);
+	void updateValue(const SessionInfoIf::SPtr& si);
 
 	template <typename T>
 	T getActualValue() const {

--- a/src/SessionInfo.cpp
+++ b/src/SessionInfo.cpp
@@ -27,7 +27,7 @@ namespace eipScanner {
 
 		if (packet.getStatusCode() != EncapsStatusCodes::SUCCESS) {
 			throw std::runtime_error("Failed to register session in " +
-									 _socket.getHost() + ":" + std::to_string(_socket.getPort()));
+									 _socket.getRemoteEndPoint().toString());
 		}
 
 		_sessionHandle = packet.getSessionHandle();
@@ -72,8 +72,8 @@ namespace eipScanner {
 		return _sessionHandle;
 	}
 
-	std::string SessionInfo::getHost() const {
-		return _socket.getHost();
+	sockets::EndPoint SessionInfo::getRemoteEndPoint() const {
+		return _socket.getRemoteEndPoint();
 	}
 
 }

--- a/src/SessionInfo.cpp
+++ b/src/SessionInfo.cpp
@@ -44,7 +44,7 @@ namespace eipScanner {
 		Logger(LogLevel::INFO) << "Unregistered session " << _sessionHandle;
 	}
 
-	EncapsPacket SessionInfo::sendAndReceive(const EncapsPacket& packet) {
+	EncapsPacket SessionInfo::sendAndReceive(const EncapsPacket& packet) const {
 		_socket.Send(packet.pack());
 		auto header = _socket.Receive(EncapsPacket::HEADER_SIZE);
 		auto length = EncapsPacket::GetLengthFromHeader(header);

--- a/src/SessionInfo.h
+++ b/src/SessionInfo.h
@@ -9,23 +9,21 @@
 #include <vector>
 #include <memory>
 
-#include "eip/EncapsPacket.h"
+#include "SessionInfoIf.h"
 #include "sockets/TCPSocket.h"
 
 namespace eipScanner {
-	class SessionInfo {
+	class SessionInfo : public SessionInfoIf {
 	public:
 		using SPtr = std::shared_ptr<SessionInfo>;
-		using WPtr = std::weak_ptr<SessionInfo>;
 
 		SessionInfo(const std::string &host, int port, const std::chrono::milliseconds& recvTimeout);
 		SessionInfo(const std::string &host, int port);
 		~SessionInfo();
 
-		virtual eip::EncapsPacket sendAndReceive(const eip::EncapsPacket& packet) const;
-
-		cip::CipUdint getSessionHandle() const;
-		std::string getHost() const;
+		eip::EncapsPacket sendAndReceive(const eip::EncapsPacket& packet) const override;
+		cip::CipUdint getSessionHandle() const override;
+		std::string getHost() const override;
 
 	private:
 		sockets::TCPSocket _socket;

--- a/src/SessionInfo.h
+++ b/src/SessionInfo.h
@@ -22,7 +22,7 @@ namespace eipScanner {
 		SessionInfo(const std::string &host, int port);
 		~SessionInfo();
 
-		virtual eip::EncapsPacket sendAndReceive(const eip::EncapsPacket& packet);
+		virtual eip::EncapsPacket sendAndReceive(const eip::EncapsPacket& packet) const;
 
 		cip::CipUdint getSessionHandle() const;
 		std::string getHost() const;

--- a/src/SessionInfo.h
+++ b/src/SessionInfo.h
@@ -23,7 +23,7 @@ namespace eipScanner {
 
 		eip::EncapsPacket sendAndReceive(const eip::EncapsPacket& packet) const override;
 		cip::CipUdint getSessionHandle() const override;
-		std::string getHost() const override;
+		sockets::EndPoint getRemoteEndPoint() const override;
 
 	private:
 		sockets::TCPSocket _socket;

--- a/src/SessionInfoIf.h
+++ b/src/SessionInfoIf.h
@@ -6,6 +6,8 @@
 #define EIPSCANNER_SESSIONINFOIF_H
 
 #include "eip/EncapsPacket.h"
+#include "sockets/EndPoint.h"
+
 namespace eipScanner {
 
 	class SessionInfoIf {
@@ -16,7 +18,7 @@ namespace eipScanner {
 
 		virtual cip::CipUdint getSessionHandle() const = 0;
 
-		virtual std::string getHost() const = 0;
+		virtual sockets::EndPoint getRemoteEndPoint() const = 0;
 	};
 }
 #endif //EIPSCANNER_SESSIONINFOIF_H

--- a/src/SessionInfoIf.h
+++ b/src/SessionInfoIf.h
@@ -1,0 +1,22 @@
+//
+// Created by Aleksey Timin on 12/10/19.
+//
+
+#ifndef EIPSCANNER_SESSIONINFOIF_H
+#define EIPSCANNER_SESSIONINFOIF_H
+
+#include "eip/EncapsPacket.h"
+namespace eipScanner {
+
+	class SessionInfoIf {
+	public:
+		using SPtr = std::shared_ptr<SessionInfoIf>;
+
+		virtual eip::EncapsPacket sendAndReceive(const eip::EncapsPacket &packet) const = 0;
+
+		virtual cip::CipUdint getSessionHandle() const = 0;
+
+		virtual std::string getHost() const = 0;
+	};
+}
+#endif //EIPSCANNER_SESSIONINFOIF_H

--- a/src/cip/MessageRouterResponse.cpp
+++ b/src/cip/MessageRouterResponse.cpp
@@ -16,7 +16,8 @@ namespace cip {
 		: _serviceCode{ServiceCodes::GET_ATTRIBUTE_ALL}
 		, _generalStatusCode{GeneralStatusCodes::SUCCESS}
 		, _additionalStatus(0)
-		, _data(0) {
+		, _data(0)
+		, _additionalPacketItems(0) {
 	}
 
 	MessageRouterResponse::~MessageRouterResponse() = default;
@@ -66,6 +67,15 @@ namespace cip {
 
 	void MessageRouterResponse::setData(const std::vector<uint8_t> &data) {
 		_data = data;
+	}
+
+	const std::vector<eip::CommonPacketItem> &MessageRouterResponse::getAdditionalPacketItems() const {
+		return _additionalPacketItems;
+	}
+
+	void
+	MessageRouterResponse::setAdditionalPacketItems(const std::vector<eip::CommonPacketItem> &_additionalPacketItems) {
+		MessageRouterResponse::_additionalPacketItems = _additionalPacketItems;
 	}
 
 	void logGeneralAndAdditionalStatus(const MessageRouterResponse &response) {

--- a/src/cip/MessageRouterResponse.h
+++ b/src/cip/MessageRouterResponse.h
@@ -10,6 +10,7 @@
 
 #include "GeneralStatusCodes.h"
 #include "Services.h"
+#include "eip/CommonPacketItem.h"
 
 namespace eipScanner {
 namespace cip {
@@ -24,15 +25,19 @@ namespace cip {
 		ServiceCodes getServiceCode() const;
 		const std::vector<uint16_t> &getAdditionalStatus() const;
 		const std::vector<uint8_t> &getData() const;
+		const eip::CommonPacketItem::Vec &getAdditionalPacketItems() const;
 
 		void setGeneralStatusCode(GeneralStatusCodes generalStatusCode);
-
 		void setData(const std::vector<uint8_t> &data);
+
+		void setAdditionalPacketItems(const std::vector<eip::CommonPacketItem> &_additionalPacketItems);
+
 	private:
 		ServiceCodes _serviceCode;
 		GeneralStatusCodes _generalStatusCode;
 		std::vector<uint16_t> _additionalStatus;
 		std::vector<uint8_t> _data;
+		eip::CommonPacketItem::Vec _additionalPacketItems;
 	};
 
 	void logGeneralAndAdditionalStatus(const MessageRouterResponse& response);

--- a/src/eip/CommonPacket.cpp
+++ b/src/eip/CommonPacket.cpp
@@ -54,8 +54,8 @@ namespace eip {
 		}
 	}
 
-	CommonPacketItem &CommonPacket::operator[](size_t index) {
-		return _items[index];
+	const CommonPacketItem::Vec &CommonPacket::getItems() {
+		return _items;
 	}
 }
 }

--- a/src/eip/CommonPacket.cpp
+++ b/src/eip/CommonPacket.cpp
@@ -38,7 +38,7 @@ namespace eip {
 		Buffer buffer(data);
 		cip::CipUint count;
 		buffer >> count;
-		for (int i = 0; i < count; ++i) {
+		for (int i = 0; i < count && !buffer.empty(); ++i) {
 			cip::CipUint typeId;
 			cip::CipUint length;
 			buffer >> typeId >> length;

--- a/src/eip/CommonPacket.h
+++ b/src/eip/CommonPacket.h
@@ -19,7 +19,7 @@ namespace eip {
 
 		std::vector<uint8_t> pack() const;
 		void expand(const std::vector<uint8_t>& data);
-		CommonPacketItem& operator [](size_t index);
+		const CommonPacketItem::Vec& getItems();
 	private:
 		CommonPacketItem::Vec _items;
 	};

--- a/src/eip/CommonPacketItem.cpp
+++ b/src/eip/CommonPacketItem.cpp
@@ -46,5 +46,15 @@ namespace eip {
 	const std::vector<uint8_t> &CommonPacketItem::getData() const {
 		return _data;
 	}
+
+	bool CommonPacketItem::operator==(const CommonPacketItem &rhs) const {
+		return _typeId == rhs._typeId &&
+			   _length == rhs._length &&
+			   _data == rhs._data;
+	}
+
+	bool CommonPacketItem::operator!=(const CommonPacketItem &rhs) const {
+		return !(rhs == *this);
+	}
 }
 }

--- a/src/eip/CommonPacketItem.h
+++ b/src/eip/CommonPacketItem.h
@@ -16,9 +16,11 @@ namespace eip {
 		NULL_ADDR = 0x0000,
 		LIST_IDENTITY = 0x000C,
 		CONNECTION_ADDRESS_ITEM= 0x00A1,
-		SEQUENCED_ADDRESS_ITEM= 0x8002,
 		CONNECTED_TRANSPORT_PACKET = 0x00B1,
-		UNCONNECTED_MESSAGE = 0x00B2
+		UNCONNECTED_MESSAGE = 0x00B2,
+		O2T_SOCKADDR_INFO = 0x8000,
+		T2O_SOCKADDR_INFO = 0x8001,
+		SEQUENCED_ADDRESS_ITEM= 0x8002,
 	};
 
 	class CommonPacketItem {
@@ -34,6 +36,10 @@ namespace eip {
 		CommonPacketItemIds getTypeId() const;
 		cip::CipUint getLength() const;
 		const std::vector<uint8_t> &getData() const;
+
+		bool operator==(const CommonPacketItem &rhs) const;
+
+		bool operator!=(const CommonPacketItem &rhs) const;
 
 	private:
 		CommonPacketItemIds _typeId;

--- a/src/eip/EncapsPacket.cpp
+++ b/src/eip/EncapsPacket.cpp
@@ -106,5 +106,19 @@ namespace eip {
 		buf >> len;
 		return len;
 	}
+
+	bool EncapsPacket::operator==(const EncapsPacket &rhs) const {
+		return _command == rhs._command &&
+			   _length == rhs._length &&
+			   _sessionHandle == rhs._sessionHandle &&
+			   _statusCode == rhs._statusCode &&
+			   _context == rhs._context &&
+			   _options == rhs._options &&
+			   _data == rhs._data;
+	}
+
+	bool EncapsPacket::operator!=(const EncapsPacket &rhs) const {
+		return !(rhs == *this);
+	}
 }
 }

--- a/src/eip/EncapsPacket.h
+++ b/src/eip/EncapsPacket.h
@@ -61,6 +61,13 @@ namespace eip {
 		const std::vector<uint8_t> &getData() const;
 		void setData(const std::vector<uint8_t> &data);
 
+
+	private:
+	public:
+		bool operator==(const EncapsPacket &rhs) const;
+
+		bool operator!=(const EncapsPacket &rhs) const;
+
 	private:
 		EncapsCommands _command;
 		cip::CipUint _length;

--- a/src/fileObject/FileObjectEmptyState.cpp
+++ b/src/fileObject/FileObjectEmptyState.cpp
@@ -12,11 +12,11 @@ namespace fileObject {
 			: FileObjectState(FileObjectStateCodes::FILE_EMPTY, owner, objectId, messageRouter) {
 	}
 
-	void FileObjectEmptyState::initiateUpload(SessionInfo::SPtr si, EndUploadHandler handle) {
+	void FileObjectEmptyState::initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handle) {
 		logWithStateName(LogLevel::WARNING, "File cannot be uploaded");
 	}
 
-	bool FileObjectEmptyState::transfer(SessionInfo::SPtr si) {
+	bool FileObjectEmptyState::transfer(SessionInfoIf::SPtr si) {
 		logWithStateName(LogLevel::WARNING, "Nothing to transfer");
 		return false;
 	}

--- a/src/fileObject/FileObjectEmptyState.h
+++ b/src/fileObject/FileObjectEmptyState.h
@@ -13,9 +13,9 @@ namespace fileObject {
 	class FileObjectEmptyState : public FileObjectState {
 	public:
 		FileObjectEmptyState(FileObject &owner, cip::CipUint objectId, MessageRouter::SPtr messageRouter);
-		void initiateUpload(SessionInfo::SPtr si, EndUploadHandler handle) override;
+		void initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handle) override;
 
-		bool transfer(SessionInfo::SPtr si) override;
+		bool transfer(SessionInfoIf::SPtr si) override;
 	};
 }
 }

--- a/src/fileObject/FileObjectLoadedState.cpp
+++ b/src/fileObject/FileObjectLoadedState.cpp
@@ -16,7 +16,7 @@ namespace fileObject {
 			: FileObjectState(FileObjectStateCodes::FILE_LOADED, owner, objectId, messageRouter) {
 	}
 
-	void FileObjectLoadedState::initiateUpload(SessionInfo::SPtr si, EndUploadHandler handler) {
+	void FileObjectLoadedState::initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handler) {
 		logWithStateName(LogLevel::INFO, "Initiate upload");
 		Buffer buffer;
 		buffer << MAX_TRANSFER_SIZE;
@@ -39,7 +39,7 @@ namespace fileObject {
 		}
 	}
 
-	bool FileObjectLoadedState::transfer(SessionInfo::SPtr si) {
+	bool FileObjectLoadedState::transfer(SessionInfoIf::SPtr si) {
 		return false;
 	}
 }

--- a/src/fileObject/FileObjectLoadedState.h
+++ b/src/fileObject/FileObjectLoadedState.h
@@ -14,8 +14,8 @@ namespace fileObject {
 	public:
 		FileObjectLoadedState(FileObject &owner, cip::CipUint objectId, MessageRouter::SPtr messageRouter);
 
-		void initiateUpload(SessionInfo::SPtr si, EndUploadHandler handler) override;
-		bool transfer(SessionInfo::SPtr si) override;
+		void initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handler) override;
+		bool transfer(SessionInfoIf::SPtr si) override;
 	};
 
 }

--- a/src/fileObject/FileObjectNonExistentState.cpp
+++ b/src/fileObject/FileObjectNonExistentState.cpp
@@ -13,12 +13,12 @@ namespace fileObject {
 			: FileObjectState(FileObjectStateCodes::NONEXISTENT, owner, objectId, messageRouter) {
 	}
 
-	void FileObjectNonExistentState::initiateUpload(SessionInfo::SPtr si, EndUploadHandler handle) {
+	void FileObjectNonExistentState::initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handle) {
 		logWithStateName(LogLevel::WARNING,
 						 "File cannot be uploaded");
 	}
 
-	bool FileObjectNonExistentState::transfer(SessionInfo::SPtr si) {
+	bool FileObjectNonExistentState::transfer(SessionInfoIf::SPtr si) {
 		logWithStateName(LogLevel::WARNING,
 						 "Nothing to transfer");
 		return false;

--- a/src/fileObject/FileObjectNonExistentState.h
+++ b/src/fileObject/FileObjectNonExistentState.h
@@ -14,8 +14,8 @@ namespace fileObject {
 	public:
 		FileObjectNonExistentState(FileObject &owner, cip::CipUint objectId, MessageRouter::SPtr messageRouter);
 
-		void initiateUpload(SessionInfo::SPtr si, EndUploadHandler handle) override;
-		bool transfer(SessionInfo::SPtr si) override;
+		void initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handle) override;
+		bool transfer(SessionInfoIf::SPtr si) override;
 	};
 
 }

--- a/src/fileObject/FileObjectState.cpp
+++ b/src/fileObject/FileObjectState.cpp
@@ -54,7 +54,7 @@ namespace fileObject {
 		return NAMES_MAP.at(_stateCode);
 	}
 
-	void FileObjectState::SyncState(SessionInfo::SPtr si) {
+	void FileObjectState::SyncState(SessionInfoIf::SPtr si) {
 		auto response = _messageRouter->sendRequest(si, cip::ServiceCodes::GET_ATTRIBUTE_SINGLE,
 												   cip::EPath(FILE_OBJECT_CLASS_ID, _objectId,
 															  static_cast<cip::CipUint>(FileObjectAttributesCodes::STATE)), {});
@@ -89,11 +89,11 @@ namespace fileObject {
 		}
 	}
 
-	void FileObjectState::initiateUpload(SessionInfo::SPtr si, EndUploadHandler handle) {
+	void FileObjectState::initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handle) {
 		logWithStateName(LogLevel::ERROR, "Not implemented call");
 	}
 
-	bool FileObjectState::transfer(SessionInfo::SPtr si) {
+	bool FileObjectState::transfer(SessionInfoIf::SPtr si) {
 		logWithStateName(LogLevel::ERROR, "Not implemented call");
 		return false;
 	}

--- a/src/fileObject/FileObjectState.h
+++ b/src/fileObject/FileObjectState.h
@@ -41,11 +41,11 @@ namespace fileObject {
 		FileObjectState(FileObjectStateCodes state, FileObject &owner, cip::CipUint objectId, MessageRouter::SPtr messageRouter);
 		virtual ~FileObjectState();
 
-		virtual void initiateUpload(SessionInfo::SPtr si, EndUploadHandler handle);
-		virtual bool transfer(SessionInfo::SPtr si);
+		virtual void initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handle);
+		virtual bool transfer(SessionInfoIf::SPtr si);
 
 		FileObjectStateCodes getStateCode() const;
-		void SyncState(SessionInfo::SPtr si);
+		void SyncState(SessionInfoIf::SPtr si);
 
 	protected:
 		void logWithStateName(utils::LogLevel logLevel, const std::string &message) const;

--- a/src/fileObject/FileObjectUploadInProgressState.cpp
+++ b/src/fileObject/FileObjectUploadInProgressState.cpp
@@ -24,12 +24,12 @@ namespace fileObject {
 	}
 
 	void
-	FileObjectUploadInProgressState::initiateUpload(SessionInfo::SPtr si, EndUploadHandler handle) {
+	FileObjectUploadInProgressState::initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handle) {
 		logWithStateName(LogLevel::INFO, "Initiate upload of file again");
 		//TODO: Implement
 	}
 
-	bool FileObjectUploadInProgressState::transfer(SessionInfo::SPtr si) {
+	bool FileObjectUploadInProgressState::transfer(SessionInfoIf::SPtr si) {
 		Buffer buffer;
 		buffer << _transferNumber;
 

--- a/src/fileObject/FileObjectUploadInProgressState.h
+++ b/src/fileObject/FileObjectUploadInProgressState.h
@@ -15,8 +15,8 @@ namespace fileObject {
 		FileObjectUploadInProgressState(FileObject &owner, cip::CipUint objectId, MessageRouter::SPtr messageRouter,
 										cip::CipUdint fileSize, cip::CipUsint transferSize, EndUploadHandler handler);
 
-		void initiateUpload(SessionInfo::SPtr si, EndUploadHandler handle) override;
-		bool transfer(SessionInfo::SPtr si) override;
+		void initiateUpload(SessionInfoIf::SPtr si, EndUploadHandler handle) override;
+		bool transfer(SessionInfoIf::SPtr si) override;
 
 	private:
 		cip::CipUdint _fileSize;

--- a/src/sockets/BaseSocket.cpp
+++ b/src/sockets/BaseSocket.cpp
@@ -11,25 +11,22 @@
 
 namespace eipScanner {
 namespace sockets {
-	BaseSocket::BaseSocket(std::string host, int port)
-			: _host{std::move(host)}
-			, _port{port}
+
+	BaseSocket::BaseSocket(EndPoint endPoint)
+			: _remoteEndPoint(std::move(endPoint))
 			, _recvTimeout(0)
 			, _beginReceiveHandler() {
+	}
+
+
+	BaseSocket::BaseSocket(std::string host, int port)
+			: BaseSocket(EndPoint(std::move(host), port)) {
 	}
 
 	BaseSocket::~BaseSocket() = default;
 
 	int BaseSocket::getSocketFd() const {
 		return _sockedFd;
-	}
-
-	const std::string &BaseSocket::getHost() const {
-		return _host;
-	}
-
-	int BaseSocket::getPort() const {
-		return _port;
 	}
 
 	const std::chrono::milliseconds &BaseSocket::getRecvTimeout() const {
@@ -102,6 +99,10 @@ namespace sockets {
 
 			startTime = std::chrono::steady_clock::now();
 		} while(ready > 0);
+	}
+
+	const EndPoint &BaseSocket::getRemoteEndPoint() const {
+		return _remoteEndPoint;
 	}
 
 }

--- a/src/sockets/BaseSocket.cpp
+++ b/src/sockets/BaseSocket.cpp
@@ -16,8 +16,8 @@ namespace sockets {
 			: _remoteEndPoint(std::move(endPoint))
 			, _recvTimeout(0)
 			, _beginReceiveHandler() {
-	}
 
+	}
 
 	BaseSocket::BaseSocket(std::string host, int port)
 			: BaseSocket(EndPoint(std::move(host), port)) {

--- a/src/sockets/BaseSocket.cpp
+++ b/src/sockets/BaseSocket.cpp
@@ -57,6 +57,9 @@ namespace sockets {
 #endif
 
 		};
+
+		tv.tv_sec = std::max<decltype(tv.tv_sec)>(tv.tv_sec, 0);
+        tv.tv_usec = std::max<decltype(tv.tv_usec)>(tv.tv_usec, 0);
 		return tv;
 	}
 

--- a/src/sockets/BaseSocket.h
+++ b/src/sockets/BaseSocket.h
@@ -23,7 +23,7 @@ namespace sockets {
 		virtual ~BaseSocket();
 
 		virtual void Send(const std::vector<uint8_t>& data) const = 0;
-		virtual std::vector<uint8_t> Receive(size_t size) = 0;
+		virtual std::vector<uint8_t> Receive(size_t size) const = 0;
 		void setBeginReceiveHandler(BeginReceiveHandler handler);
 
 

--- a/src/sockets/BaseSocket.h
+++ b/src/sockets/BaseSocket.h
@@ -12,6 +12,8 @@
 #include <functional>
 #include <memory>
 
+#include "EndPoint.h"
+
 namespace eipScanner {
 namespace sockets {
 	class BaseSocket {
@@ -19,6 +21,7 @@ namespace sockets {
 		using BeginReceiveHandler = std::function<void(BaseSocket&)>;
 		using SPtr = std::shared_ptr<BaseSocket>;
 
+		explicit BaseSocket(EndPoint endPoint);
 		BaseSocket(std::string host, int port);
 		virtual ~BaseSocket();
 
@@ -31,8 +34,8 @@ namespace sockets {
 		void setRecvTimeout(const std::chrono::milliseconds &recvTimeout);
 
 		int getSocketFd() const;
-		const std::string &getHost() const;
-		int getPort() const;
+
+		const EndPoint &getRemoteEndPoint() const;
 
 		static void select(std::vector<BaseSocket::SPtr> sockets, std::chrono::milliseconds timeout);
 
@@ -40,8 +43,7 @@ namespace sockets {
 		void BeginReceive();
 
 		int _sockedFd;
-		std::string _host;
-		int _port;
+		EndPoint _remoteEndPoint;
 
 		std::chrono::milliseconds _recvTimeout;
 		BeginReceiveHandler _beginReceiveHandler;

--- a/src/sockets/EndPoint.cpp
+++ b/src/sockets/EndPoint.cpp
@@ -1,0 +1,64 @@
+//
+// Created by Aleksey Timin on 12/10/19.
+//
+
+#include "EndPoint.h"
+#include <arpa/inet.h>
+#include <system_error>
+#include <utility>
+
+namespace eipScanner {
+namespace sockets {
+
+	EndPoint::EndPoint(struct sockaddr_in &addr)
+		: _host(inet_ntoa(addr.sin_addr))
+		, _port(htons(addr.sin_port))
+		, _addr(addr) {
+	}
+
+	EndPoint::EndPoint(std::string host, int port)
+		: _host(std::move(host))
+		, _port(port)
+		, _addr{0} {
+
+		_addr.sin_family = AF_INET;
+		_addr.sin_port = htons(_port);
+		if (inet_aton(_host.c_str(), &_addr.sin_addr) < 0) {
+			throw std::system_error(errno, std::generic_category());
+		}
+	}
+
+	const std::string &EndPoint::getHost() const {
+		return _host;
+	}
+
+	int EndPoint::getPort() const {
+		return _port;
+	}
+
+	const sockaddr_in &EndPoint::getAddr() const {
+		return _addr;
+	}
+
+	bool EndPoint::operator==(const EndPoint &rhs) const {
+		return _host == rhs._host &&
+			   _port == rhs._port &&
+			   _addr.sin_addr.s_addr == rhs._addr.sin_addr.s_addr &&
+			   _addr.sin_port == rhs._addr.sin_port &&
+			   _addr.sin_family == rhs._addr.sin_family;
+	}
+
+	bool EndPoint::operator!=(const EndPoint &rhs) const {
+		return !(rhs == *this);
+	}
+
+	bool EndPoint::operator< (const EndPoint& rhs) const {
+		return _host < rhs._host
+			   && _port < rhs._port;
+	}
+
+	std::string EndPoint::toString() const {
+		return _host + ":" + std::to_string(_port);
+	}
+}
+}

--- a/src/sockets/EndPoint.h
+++ b/src/sockets/EndPoint.h
@@ -1,0 +1,36 @@
+//
+// Created by Aleksey Timin on 12/10/19.
+//
+
+#ifndef EIPSCANNER_SOCKETS_ENDPOINT_H
+#define EIPSCANNER_SOCKETS_ENDPOINT_H
+
+#include <netinet/in.h>
+#include <string>
+
+namespace eipScanner {
+namespace sockets {
+
+	class EndPoint {
+	public:
+		EndPoint(std::string  host, int port);
+		EndPoint(struct sockaddr_in& addr);
+
+		const std::string &getHost() const;
+		int getPort() const;
+		const sockaddr_in &getAddr() const;
+
+		std::string toString() const;
+
+		bool operator==(const EndPoint &rhs) const;
+		bool operator!=(const EndPoint &rhs) const;
+		bool operator< (const EndPoint& rhs) const;
+	private:
+		std::string _host;
+		int _port;
+		struct sockaddr_in _addr;
+	};
+}
+}
+
+#endif  // EIPSCANNER_ENDPOINT_H

--- a/src/sockets/TCPSocket.cpp
+++ b/src/sockets/TCPSocket.cpp
@@ -60,7 +60,7 @@ namespace sockets {
 		}
 	}
 
-	std::vector<uint8_t> TCPSocket::Receive(size_t size) {
+	std::vector<uint8_t> TCPSocket::Receive(size_t size) const {
 		std::vector<uint8_t> recvBuffer(size);
 
 		int count = 0;

--- a/src/sockets/TCPSocket.h
+++ b/src/sockets/TCPSocket.h
@@ -17,7 +17,7 @@ namespace sockets {
 		virtual ~TCPSocket();
 
 		void Send(const std::vector<uint8_t>& data) const override;
-		std::vector<uint8_t> Receive(size_t size) override;
+		std::vector<uint8_t> Receive(size_t size) const override;
 
 	private:
 	};

--- a/src/sockets/TCPSocket.h
+++ b/src/sockets/TCPSocket.h
@@ -13,6 +13,7 @@ namespace eipScanner {
 namespace sockets {
 	class TCPSocket : public BaseSocket {
 	public:
+		explicit TCPSocket(EndPoint endPoint);
 		TCPSocket(std::string host, int port);
 		virtual ~TCPSocket();
 

--- a/src/sockets/UDPBoundSocket.cpp
+++ b/src/sockets/UDPBoundSocket.cpp
@@ -8,13 +8,20 @@
 
 namespace eipScanner {
 namespace sockets {
-	UDPBoundSocket::UDPBoundSocket(std::string host, int port) : UDPSocket(host, port) {
+
+
+	UDPBoundSocket::UDPBoundSocket(std::string host, int port)
+		: UDPBoundSocket(EndPoint(host, port)) {
+
+	}
+	UDPBoundSocket::UDPBoundSocket(EndPoint endPoint)
+		: UDPSocket(std::move(endPoint)) {
 		int on = 1;
 		if (setsockopt(_sockedFd, SOL_SOCKET, SO_REUSEADDR, (char *) &on, sizeof(on)) < 0) {
 			throw std::system_error(errno, std::generic_category());
 		}
 
-		auto addr = _addr;
+		auto addr = _remoteEndPoint.getAddr();
 		addr.sin_addr.s_addr = INADDR_ANY;
 		if (bind(_sockedFd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 			throw std::system_error(errno, std::generic_category());

--- a/src/sockets/UDPBoundSocket.h
+++ b/src/sockets/UDPBoundSocket.h
@@ -19,6 +19,7 @@ namespace sockets {
 		using WPtr = std::weak_ptr<UDPBoundSocket>;
 		using SPtr = std::shared_ptr<UDPBoundSocket>;
 
+		explicit UDPBoundSocket(EndPoint endPoint);
 		UDPBoundSocket(std::string host, int port);
 		virtual ~UDPBoundSocket();
 	};

--- a/src/sockets/UDPSocket.cpp
+++ b/src/sockets/UDPSocket.cpp
@@ -16,8 +16,16 @@ namespace sockets {
 	using eipScanner::utils::Logger;
 	using eipScanner::utils::LogLevel;
 
+
+
+
 	UDPSocket::UDPSocket(std::string host, int port)
-			: BaseSocket{host, port} {
+		: UDPSocket(EndPoint(host, port)){
+
+	}
+
+	UDPSocket::UDPSocket(EndPoint endPoint)
+			: BaseSocket(EndPoint(std::move(endPoint))) {
 
 		_sockedFd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 		if (_sockedFd < 0) {
@@ -25,16 +33,6 @@ namespace sockets {
 		}
 
 		Logger(LogLevel::DEBUG) << "Opened socket fd=" << _sockedFd;
-
-		Logger(LogLevel::DEBUG) << "Parsing IP from " << _host;
-
-		if (inet_aton(_host.c_str(), &_addr.sin_addr) < 0) {
-			close(_sockedFd);
-			throw std::system_error(errno, std::generic_category());
-		}
-
-		_addr.sin_family = AF_INET;
-		_addr.sin_port = htons(_port);
 	}
 
 	UDPSocket::~UDPSocket() {
@@ -46,8 +44,9 @@ namespace sockets {
 	void UDPSocket::Send(const std::vector <uint8_t> &data) const {
 		Logger(LogLevel::TRACE) << "Send " << data.size() << " bytes from TCP socket #" << _sockedFd << ".";
 
+		auto addr = _remoteEndPoint.getAddr();
 		int count = sendto(_sockedFd, data.data(), data.size(), 0,
-				(struct sockaddr *)&_addr, sizeof(_addr));
+				(struct sockaddr *)&addr, sizeof(addr));
 		if (count < data.size()) {
 			throw std::system_error(errno, std::generic_category());
 		}

--- a/src/sockets/UDPSocket.cpp
+++ b/src/sockets/UDPSocket.cpp
@@ -53,7 +53,7 @@ namespace sockets {
 		}
 	}
 
-	std::vector<uint8_t> UDPSocket::Receive(size_t size) {
+	std::vector<uint8_t> UDPSocket::Receive(size_t size) const {
 		std::vector<uint8_t> recvBuffer(size);
 
 		auto len = recvfrom(_sockedFd, recvBuffer.data(), recvBuffer.size(), 0, NULL, NULL);

--- a/src/sockets/UDPSocket.cpp
+++ b/src/sockets/UDPSocket.cpp
@@ -42,7 +42,7 @@ namespace sockets {
 	}
 
 	void UDPSocket::Send(const std::vector <uint8_t> &data) const {
-		Logger(LogLevel::TRACE) << "Send " << data.size() << " bytes from TCP socket #" << _sockedFd << ".";
+		Logger(LogLevel::TRACE) << "Send " << data.size() << " bytes from UDP socket #" << _sockedFd << ".";
 
 		auto addr = _remoteEndPoint.getAddr();
 		int count = sendto(_sockedFd, data.data(), data.size(), 0,

--- a/src/sockets/UDPSocket.h
+++ b/src/sockets/UDPSocket.h
@@ -24,7 +24,7 @@ namespace sockets {
 		virtual ~UDPSocket();
 
 		void Send(const std::vector<uint8_t>& data) const override;
-		std::vector<uint8_t> Receive(size_t size) override ;
+		std::vector<uint8_t> Receive(size_t size) const override ;
 
 
 	protected:

--- a/src/sockets/UDPSocket.h
+++ b/src/sockets/UDPSocket.h
@@ -20,15 +20,12 @@ namespace sockets {
 		using SPtr = std::shared_ptr<UDPSocket>;
 		using UPtr = std::unique_ptr<UDPSocket>;
 
+		explicit UDPSocket(EndPoint endPoint);
 		UDPSocket(std::string host, int port);
 		virtual ~UDPSocket();
 
 		void Send(const std::vector<uint8_t>& data) const override;
 		std::vector<uint8_t> Receive(size_t size) const override ;
-
-
-	protected:
-		struct sockaddr_in _addr;
 	};
 }
 }

--- a/src/utils/Buffer.cpp
+++ b/src/utils/Buffer.cpp
@@ -142,5 +142,27 @@ namespace utils {
 		val = cip::CipRevision(majorRevision, minorRevision);
 		return *this;
 	}
+
+	Buffer &Buffer::operator<<(sockets::EndPoint v) {
+		std::vector<uint8_t> zeros(8);
+		sockaddr_in addr = v.getAddr();
+		return *this << htons(addr.sin_family)
+					 << addr.sin_port
+					 << addr.sin_addr.s_addr
+					 << zeros;
+	}
+
+	Buffer &Buffer::operator>>(sockets::EndPoint &val) {
+		std::vector<uint8_t> zeros(8);
+		sockaddr_in addr{0};
+		*this >> addr.sin_family
+			 >> addr.sin_port
+			 >> addr.sin_addr.s_addr
+			 >> zeros;
+
+		addr.sin_family =  htons(addr.sin_family);
+		val = sockets::EndPoint(addr);
+		return *this;
+	}
 }
 }

--- a/src/utils/Buffer.cpp
+++ b/src/utils/Buffer.cpp
@@ -146,7 +146,7 @@ namespace utils {
 	Buffer &Buffer::operator<<(sockets::EndPoint v) {
 		std::vector<uint8_t> zeros(8);
 		sockaddr_in addr = v.getAddr();
-		return *this << htons(addr.sin_family)
+		return *this << htons(static_cast<cip::CipInt>(addr.sin_family))
 					 << addr.sin_port
 					 << addr.sin_addr.s_addr
 					 << zeros;
@@ -155,7 +155,7 @@ namespace utils {
 	Buffer &Buffer::operator>>(sockets::EndPoint &val) {
 		std::vector<uint8_t> zeros(8);
 		sockaddr_in addr{0};
-		*this >> addr.sin_family
+		*this >> reinterpret_cast<cip::CipInt&>(addr.sin_family)
 			 >> addr.sin_port
 			 >> addr.sin_addr.s_addr
 			 >> zeros;

--- a/src/utils/Buffer.h
+++ b/src/utils/Buffer.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include "cip/CipString.h"
 #include "cip/CipRevision.h"
+#include "sockets/EndPoint.h"
 
 namespace eipScanner {
 namespace utils {
@@ -66,7 +67,10 @@ namespace utils {
 		}
 
 		Buffer& operator << (cip::CipRevision v);
-		Buffer& operator >> (cip::CipRevision & val);
+		Buffer& operator >> (cip::CipRevision& val);
+
+		Buffer& operator << (sockets::EndPoint v);
+		Buffer& operator >> (sockets::EndPoint& val);
 
 		std::vector<uint8_t> data() const { return _buffer; }
 		size_t size() const { return _buffer.size(); }

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -9,7 +9,7 @@
 namespace eipScanner {
 namespace utils {
 	LogLevel Logger::_globalLogLevel = LogLevel::INFO;
-	LogAppender::UPtr Logger::_appender = std::make_unique<ConsoleAppender>();
+	LogAppenderIf::UPtr Logger::_appender = std::make_unique<ConsoleAppender>();
 
 	Logger::Logger(LogLevel logLevel): _logLevel{logLevel} {
 
@@ -37,7 +37,7 @@ namespace utils {
 		_globalLogLevel = level;
 	}
 
-	void Logger::setAppender(LogAppender::UPtr appender) {
+	void Logger::setAppender(LogAppenderIf::UPtr appender) {
 		_appender = std::move(appender);
 	}
 

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -20,17 +20,17 @@ namespace utils {
 		TRACE
 	};
 
-	class LogAppender {
+	class LogAppenderIf {
 	public:
-		using UPtr = std::unique_ptr<LogAppender>;
-		virtual ~LogAppender() = default;
+		using UPtr = std::unique_ptr<LogAppenderIf>;
+		virtual ~LogAppenderIf() = default;
 
 		virtual void print(const std::string& msg) = 0;
 	};
 
-	class ConsoleAppender : public LogAppender {
+	class ConsoleAppender : public LogAppenderIf {
 	public:
-		using UPtr = std::unique_ptr<LogAppender>;
+		using UPtr = std::unique_ptr<LogAppenderIf>;
 		void print(const std::string& msg) override;
 	};
 
@@ -38,7 +38,7 @@ namespace utils {
 	class Logger {
 	public:
 		static void setLogLevel(LogLevel level);
-		static void setAppender(LogAppender::UPtr appender);
+		static void setAppender(LogAppenderIf::UPtr appender);
 
 		Logger(LogLevel level);
 
@@ -52,7 +52,7 @@ namespace utils {
 
 	private:
 		static LogLevel _globalLogLevel;
-		static LogAppender::UPtr _appender;
+		static LogAppenderIf::UPtr _appender;
 
 		LogLevel _logLevel;
 		std::ostringstream _stream;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,8 @@ add_executable(test_eipscanner
         fileObject/TestFileObjectLoadedState.cpp
         fileObject/TestFileObjectUploadInProgressState.cpp
 
+        sockets/TestEndPoint.cpp
+
         utils/TestBuffer.cpp
 
         TestIdentityObject.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(test_eipscanner
         utils/TestBuffer.cpp
 
         TestIdentityObject.cpp
+        TestMessageRouter.cpp
         TestParameterObject.cpp
         test.cpp
         )

--- a/test/Mocks.h
+++ b/test/Mocks.h
@@ -19,5 +19,10 @@ public:
 			const std::vector<uint8_t> &data));
 };
 
+class TMockSessionInfo : public eipScanner::SessionInfo {
+public:
+	using SPtr = std::shared_ptr<TMockSessionInfo>;
+	MOCK_CONST_METHOD1(sendAndReceive, eipScanner::eip::EncapsPacket(const eipScanner::eip::EncapsPacket& packet));
+};
 
 #endif //EIPSCANNER_MOCKS_H

--- a/test/Mocks.h
+++ b/test/Mocks.h
@@ -12,11 +12,23 @@ class TMockMessageRouter : public eipScanner::MessageRouter {
 public:
 	using SPtr = std::shared_ptr<TMockMessageRouter>;
 
+	MOCK_CONST_METHOD3(sendRequest, eipScanner::cip::MessageRouterResponse(
+			eipScanner::SessionInfoIf::SPtr si,
+			eipScanner::cip::CipUsint service,
+			const eipScanner::cip::EPath &path));
+
 	MOCK_CONST_METHOD4(sendRequest, eipScanner::cip::MessageRouterResponse(
-			eipScanner::SessionInfo::SPtr si,
+			eipScanner::SessionInfoIf::SPtr si,
 			eipScanner::cip::CipUsint service,
 			const eipScanner::cip::EPath &path,
 			const std::vector<uint8_t> &data));
+
+	MOCK_CONST_METHOD5(sendRequest, eipScanner::cip::MessageRouterResponse(
+			eipScanner::SessionInfoIf::SPtr si,
+			eipScanner::cip::CipUsint service,
+			const eipScanner::cip::EPath &path,
+			const std::vector<uint8_t> &data,
+			const eipScanner::eip::CommonPacketItem::Vec&));
 };
 
 class TMockSessionInfo : public eipScanner::SessionInfoIf {
@@ -24,7 +36,7 @@ public:
 	using SPtr = std::shared_ptr<TMockSessionInfo>;
 	MOCK_CONST_METHOD1(sendAndReceive, eipScanner::eip::EncapsPacket(const eipScanner::eip::EncapsPacket& packet));
 	MOCK_CONST_METHOD0(getSessionHandle, eipScanner::cip::CipUdint());
-	MOCK_CONST_METHOD0(getHost, std::string());
+	MOCK_CONST_METHOD0(getRemoteEndPoint, eipScanner::sockets::EndPoint());
 };
 
 #endif //EIPSCANNER_MOCKS_H

--- a/test/Mocks.h
+++ b/test/Mocks.h
@@ -19,10 +19,12 @@ public:
 			const std::vector<uint8_t> &data));
 };
 
-class TMockSessionInfo : public eipScanner::SessionInfo {
+class TMockSessionInfo : public eipScanner::SessionInfoIf {
 public:
 	using SPtr = std::shared_ptr<TMockSessionInfo>;
 	MOCK_CONST_METHOD1(sendAndReceive, eipScanner::eip::EncapsPacket(const eipScanner::eip::EncapsPacket& packet));
+	MOCK_CONST_METHOD0(getSessionHandle, eipScanner::cip::CipUdint());
+	MOCK_CONST_METHOD0(getHost, std::string());
 };
 
 #endif //EIPSCANNER_MOCKS_H

--- a/test/TestIdentityObject.cpp
+++ b/test/TestIdentityObject.cpp
@@ -28,7 +28,7 @@ public:
 	}
 
 	TMockMessageRouter::SPtr _messageRouter;
-	SessionInfo::SPtr  _nullSession;
+	SessionInfoIf::SPtr  _nullSession;
 };
 
 TEST_F(TestIdentityObject, ShouldReadAllDataInConstructor) {

--- a/test/TestMessageRouter.cpp
+++ b/test/TestMessageRouter.cpp
@@ -1,0 +1,7 @@
+//
+// Created by Aleksey Timin on 12/10/19.
+//
+
+#include <gtest/gtest.h>
+#include "MessageRouter.h"
+

--- a/test/TestMessageRouter.cpp
+++ b/test/TestMessageRouter.cpp
@@ -3,5 +3,59 @@
 //
 
 #include <gtest/gtest.h>
+#include "Mocks.h"
 #include "MessageRouter.h"
+#include "eip/CommonPacket.h"
+#include "eip/CommonPacketItem.h"
+#include "eip/CommonPacketItemFactory.h"
+#include "eip/EncapsPacketFactory.h"
+#include "cip/MessageRouterRequest.h"
+#include "cip/MessageRouterResponse.h"
 
+using namespace eipScanner;
+
+TEST(TestMessageRouter, ShouldFormAndParseCommonPackets) {
+	auto mockSession = std::make_shared<TMockSessionInfo>();
+	MessageRouter router;
+	auto service = cip::ServiceCodes::SET_ATTRIBUTE_SINGLE;
+	cip::EPath path(1,2,3);
+	std::vector<uint8_t> data = {0,1,2,3};
+
+	cip::MessageRouterRequest request(service, path, data);
+	eip::CommonPacketItemFactory commonPacketItemFactory;
+
+	auto additionalPacketItem = commonPacketItemFactory.createNullAddressItem();
+
+	eip::CommonPacket sendCommonPacket;
+	sendCommonPacket << commonPacketItemFactory.createNullAddressItem();
+	sendCommonPacket << commonPacketItemFactory.createUnconnectedDataItem(request.pack());
+	sendCommonPacket << additionalPacketItem;
+
+	auto packetToSend = eip::EncapsPacketFactory()
+			.createSendRRDataPacket(10, 0, sendCommonPacket.pack());
+
+	eip::CommonPacket receiveCommonPacket;
+	receiveCommonPacket << commonPacketItemFactory.createNullAddressItem();
+	receiveCommonPacket << commonPacketItemFactory.createUnconnectedDataItem({
+		static_cast<cip::CipUsint>(service | 0x80),
+		0,
+		cip::GeneralStatusCodes::SUCCESS,
+		0
+	});
+	receiveCommonPacket << additionalPacketItem;
+
+	auto receivedPacket = eip::EncapsPacketFactory()
+			.createSendRRDataPacket(10, 0, receiveCommonPacket.pack());
+
+	EXPECT_CALL(*mockSession, getSessionHandle()).WillOnce(::testing::Return(10));
+	EXPECT_CALL(*mockSession, sendAndReceive(packetToSend)).WillOnce(::testing::Return(receivedPacket));
+
+	auto response = router.sendRequest(mockSession, service,
+			path,
+			data,
+			{additionalPacketItem});
+
+	EXPECT_EQ(cip::GeneralStatusCodes::SUCCESS, response.getGeneralStatusCode());
+	EXPECT_EQ(1, response.getAdditionalPacketItems().size());
+	EXPECT_EQ(additionalPacketItem, response.getAdditionalPacketItems().at(0));
+}

--- a/test/TestParameterObject.cpp
+++ b/test/TestParameterObject.cpp
@@ -82,7 +82,7 @@ public:
 	}
 
 	TMockMessageRouter::SPtr _messageRouter;
-	SessionInfo::SPtr  _nullSession;
+	SessionInfoIf::SPtr  _nullSession;
 };
 
 TEST_F(TestParameterObject, ShouldReadAllStubDataInConstructor) {

--- a/test/eip/TestCommonPacket.cpp
+++ b/test/eip/TestCommonPacket.cpp
@@ -24,8 +24,8 @@ TEST(CommonPacket, ShouldExpandFromData) {
 	CommonPacket cp;
 	cp.expand(data);
 
-	EXPECT_EQ(cp[0].getTypeId(), CommonPacketItemIds::NULL_ADDR);
-	EXPECT_EQ(cp[1].getTypeId(), CommonPacketItemIds::UNCONNECTED_MESSAGE);
+	EXPECT_EQ(cp.getItems()[0].getTypeId(), CommonPacketItemIds::NULL_ADDR);
+	EXPECT_EQ(cp.getItems()[1].getTypeId(), CommonPacketItemIds::UNCONNECTED_MESSAGE);
 }
 
 TEST(CommonPacket, ShouldThrowErrorIfDataIsInvalid) {

--- a/test/fileObject/Mocks.h
+++ b/test/fileObject/Mocks.h
@@ -5,6 +5,7 @@
 #ifndef EIPSCANNER_TEST_FILEOBJECT_MOCKS_H
 #define EIPSCANNER_TEST_FILEOBJECT_MOCKS_H
 
+#include "../Mocks.h"
 #include "MessageRouter.h"
 #include "FileObject.h"
 #include "fileObject/FileObjectState.h"
@@ -16,17 +17,9 @@ namespace fileObject {
 	using eipScanner::fileObject::FileObjectAttributesCodes;
 	using eipScanner::fileObject::FILE_OBJECT_CLASS_ID;
 
-	class MockMessageRouter : public eipScanner::MessageRouter {
-	public:
-		using SPtr = std::shared_ptr<MockMessageRouter>;
 
-		MOCK_CONST_METHOD4(sendRequest, cip::MessageRouterResponse(
-				SessionInfo::SPtr si, cip::CipUsint service, const cip::EPath &path, const std::vector<uint8_t> &data));
-	};
-
-
-	static void mockGetFileObjectState(MockMessageRouter::SPtr messageRouter,
-			SessionInfo::SPtr si, cip::CipUint objectId, FileObjectStateCodes stateCode)  {
+	static void mockGetFileObjectState(TMockMessageRouter::SPtr messageRouter,
+			SessionInfoIf::SPtr si, cip::CipUint objectId, FileObjectStateCodes stateCode)  {
 		cip::MessageRouterResponse response;
 		Buffer buffer;
 		buffer << static_cast<cip::CipUsint>(stateCode);

--- a/test/fileObject/TestFileObjectLoadedState.cpp
+++ b/test/fileObject/TestFileObjectLoadedState.cpp
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "Mocks.h"
+#include "./Mocks.h"
 #include "FileObject.h"
 #include "fileObject/FileObjectLoadedState.h"
 #include "utils/Buffer.h"
@@ -21,8 +21,8 @@ public:
 	const cip::CipUint FILE_OBJECT_ID = 1;
 
 	void SetUp() override {
-		_messageRouter = std::make_shared<fileObject::MockMessageRouter>();
-		mockGetFileObjectState(_messageRouter, _nullSession,
+		_messageRouter = std::make_shared<TMockMessageRouter>();
+		fileObject::mockGetFileObjectState(_messageRouter, _nullSession,
 				FILE_OBJECT_ID, FileObjectStateCodes::FILE_LOADED);
 
 		_fileObject = std::make_unique<FileObject>(FILE_OBJECT_ID, _nullSession, _messageRouter);
@@ -40,9 +40,9 @@ public:
 		return response;
 	}
 
-	fileObject::MockMessageRouter::SPtr _messageRouter;
+	TMockMessageRouter::SPtr _messageRouter;
 	FileObject::UPtr _fileObject;
-	SessionInfo::SPtr _nullSession;
+	SessionInfoIf::SPtr _nullSession;
 };
 
 TEST_F(TestFileObjectLoadedState, ShouldInitiateUpload) {

--- a/test/fileObject/TestFileObjectUploadInProgressState.cpp
+++ b/test/fileObject/TestFileObjectUploadInProgressState.cpp
@@ -72,7 +72,6 @@ public:
 };
 
 TEST_F(TestFileObjectUploadInProgressState, ShouldUploadTransfer) {
-
 	mockTransfer(0, TransferPacketTypeCodes::FIRST, std::vector<uint8_t>(255));
 	EXPECT_TRUE(_fileObject->handleTransfers(_nullSession));
 

--- a/test/fileObject/TestFileObjectUploadInProgressState.cpp
+++ b/test/fileObject/TestFileObjectUploadInProgressState.cpp
@@ -23,8 +23,8 @@ public:
 	const int FILE_SIZE = 255*2+10;
 
 	void SetUp() override {
-		_messageRouter = std::make_shared<fileObject::MockMessageRouter>();
-		mockGetFileObjectState(_messageRouter, _nullSession,
+		_messageRouter = std::make_shared<TMockMessageRouter>();
+		fileObject::mockGetFileObjectState(_messageRouter, _nullSession,
 				FILE_OBJECT_ID, FileObjectStateCodes::TRANSFER_UPLOAD_IN_PROGRESS);
 
 		_fileObject = std::make_unique<FileObject>(FILE_OBJECT_ID, _nullSession, _messageRouter);
@@ -63,9 +63,9 @@ public:
 		).WillOnce(Return(response));
 	}
 
-	fileObject::MockMessageRouter::SPtr _messageRouter;
+	TMockMessageRouter::SPtr _messageRouter;
 	FileObject::UPtr _fileObject;
-	SessionInfo::SPtr _nullSession;
+	SessionInfoIf::SPtr _nullSession;
 
 	cip::GeneralStatusCodes _receivedStatus;
 	std::vector<uint8_t> _receivedFile;

--- a/test/sockets/TestEndPoint.cpp
+++ b/test/sockets/TestEndPoint.cpp
@@ -1,0 +1,40 @@
+//
+// Created by Aleksey Timin on 12/10/19.
+//
+
+#include <gtest/gtest.h>
+#include "sockets/EndPoint.h"
+
+using eipScanner::sockets::EndPoint;
+
+TEST(TestEndPoint, ShouldConvertIpAndHostToAddr) {
+	EndPoint endPoint("127.0.0.1", 0xAA00);
+
+	EXPECT_EQ("127.0.0.1", endPoint.getHost());
+	EXPECT_EQ(0xAA00, endPoint.getPort());
+	EXPECT_EQ(2, endPoint.getAddr().sin_family);
+	EXPECT_EQ(0x0100007F, endPoint.getAddr().sin_addr.s_addr);
+	EXPECT_EQ(0x00AA, endPoint.getAddr().sin_port);
+	EXPECT_EQ("127.0.0.1:43520", endPoint.toString());
+}
+
+TEST(TestEndPoint, ShouldConvertAddrToIpAndHost) {
+	struct sockaddr_in addr{0};
+	addr.sin_family = 2;
+	addr.sin_addr.s_addr = 0x0100007F;
+	addr.sin_port = 0x00AA;
+
+	EndPoint endPoint(addr);
+
+	EXPECT_EQ("127.0.0.1", endPoint.getHost());
+	EXPECT_EQ(0xAA00, endPoint.getPort());
+	EXPECT_EQ(2, endPoint.getAddr().sin_family);
+	EXPECT_EQ(0x0100007F, endPoint.getAddr().sin_addr.s_addr);
+	EXPECT_EQ(0x00AA, endPoint.getAddr().sin_port);
+	EXPECT_EQ("127.0.0.1:43520", endPoint.toString());
+}
+
+TEST(TestEndPoint, ShouldNotThrowExceptionIfCanNotParseIP) {
+	EndPoint endPoint("XXXX", 0);
+	EXPECT_EQ(0, endPoint.getAddr().sin_addr.s_addr);
+}

--- a/test/utils/TestBuffer.cpp
+++ b/test/utils/TestBuffer.cpp
@@ -173,7 +173,6 @@ TEST(TestBuffer, ShouldDecodeRevision) {
 	EXPECT_EQ(expectedData, buf.data());
 }
 
-
 TEST(TestBuffer, ShouldEncodeRevision) {
 	cip::CipRevision revision;
 	std::vector<uint8_t> data = {1,2};
@@ -182,4 +181,36 @@ TEST(TestBuffer, ShouldEncodeRevision) {
 
 	EXPECT_EQ(revision.getMajorRevision(), 1);
 	EXPECT_EQ(revision.getMinorRevision(), 2);
+}
+
+TEST(TestBuffer, ShouldDecodeEndPPoint) {
+	sockets::EndPoint endPoint("127.0.0.1", 2222);
+	std::vector<uint8_t> expectedData = {
+			0x00, 0x02,
+			0x08, 0xae,
+			0x07f, 0x0, 0x0, 0x1,
+			0, 0, 0, 0, 0, 0, 0, 0
+	};
+	Buffer buf;
+	buf << endPoint;
+
+	EXPECT_EQ(expectedData, buf.data());
+}
+
+TEST(TestBuffer, ShouldEncodeEndPPoint) {
+	sockets::EndPoint endPoint("", 0);
+	std::vector<uint8_t> data =  {
+			0x00, 0x02,
+			0x08, 0xae,
+			0x07f, 0x0, 0x0, 0x1,
+			0, 0, 0, 0, 0, 0, 0, 0
+	};
+	Buffer buf(data);
+	buf >> endPoint;
+
+	EXPECT_EQ("127.0.0.1", endPoint.getHost());
+	EXPECT_EQ(2222, endPoint.getPort());
+	EXPECT_EQ(2, endPoint.getAddr().sin_family);
+	EXPECT_EQ(0x0100007f, endPoint.getAddr().sin_addr.s_addr);
+	EXPECT_EQ(0xae08, endPoint.getAddr().sin_port);
 }


### PR DESCRIPTION
Closes #9 

Currently, ConnectionManager sends T->O Sockaddr Info Item and uses the inforamtion from O->T Sockadd Info Item to open UDP sockets.