### PR TITLE
IOConnection: Add a callback before data is sent

### DIFF
--- a/src/IOConnection.cpp
+++ b/src/IOConnection.cpp
@@ -43,6 +43,7 @@ namespace eipScanner {
 			, _outputData()
 			, _lastHandleTime(std::chrono::steady_clock::now())
 			, _receiveDataHandle([](auto a, auto b, auto data) {})
+			, _sendDataHandle([](auto data) {})
 			, _closeHandle([]() {}) {
 	}
 
@@ -54,6 +55,10 @@ namespace eipScanner {
 
 	void IOConnection::setReceiveDataListener(ReceiveDataHandle handle) {
 		_receiveDataHandle = std::move(handle);
+	}
+
+	void IOConnection::setSendDataListener(SendDataHandle handle) {
+        	_sendDataHandle = std::move(handle);
 	}
 
 	void IOConnection::setCloseListener(CloseHandle handle) {
@@ -120,6 +125,7 @@ namespace eipScanner {
 			}
 
 			_o2tTimer = 0;
+			_sendDataHandle(_outputData);
 			if (_o2tFixedSize && _outputData.size() != _o2tDataSize)  {
 				Logger(LogLevel::WARNING) << "Connection O2T_ID=" << _o2tNetworkConnectionId
 										  << " has fixed size " << _o2tDataSize << " bytes but " << _outputData.size()

--- a/src/IOConnection.h
+++ b/src/IOConnection.h
@@ -25,6 +25,7 @@ namespace eipScanner {
 		friend class ConnectionManager;
 	public:
 		using ReceiveDataHandle = std::function<void(cip::CipUdint, cip::CipUint, const std::vector<uint8_t>&)>;
+		using SendDataHandle = std::function<void(std::vector<uint8_t>&)>;
 		using CloseHandle = std::function<void()>;
 
 		using WPtr=std::weak_ptr<IOConnection>;
@@ -55,6 +56,13 @@ namespace eipScanner {
 		 * @param handle
 		 */
 		void setCloseListener(CloseHandle handle);
+
+        /**
+         * @brief Sets a callback to handle data to send
+         *
+         * @param handle
+         */
+        void setSendDataListener(SendDataHandle handle);
 
 	private:
 		IOConnection();
@@ -96,6 +104,7 @@ namespace eipScanner {
 
 		ReceiveDataHandle _receiveDataHandle;
 		CloseHandle _closeHandle;
+		SendDataHandle _sendDataHandle;
 
 		std::chrono::steady_clock::time_point _lastHandleTime;
 	};


### PR DESCRIPTION
This allows to refresh current output assembly buffer before it is sent, for example this way 
```
            ptr->setSendDataListener(
                    [this, id](auto& data)
                        {
                            std::unique_lock<std::mutex> lock(_mutex);
                            data = _map[id].GetBytes();
                        }
            );
```

Signed-off-by: Vincent Prince <vincent.prince.external@saftbatteries.com>