### PR TITLE
8bit support

### DIFF
--- a/src/MessageRouter.cpp
+++ b/src/MessageRouter.cpp
@@ -22,7 +22,9 @@ namespace eipScanner {
 	using eip::EncapsPacket;
 	using eip::EncapsPacketFactory;
 
-	MessageRouter::MessageRouter() = default;
+	MessageRouter::MessageRouter(bool use_8_bit_path_segments) 
+    : _use_8_bit_path_segments(use_8_bit_path_segments)
+    {};
 
 	MessageRouter::~MessageRouter() = default;
 
@@ -41,7 +43,7 @@ namespace eipScanner {
 		Logger(LogLevel::INFO) << "Send request: service=0x" << std::hex << static_cast<int>(service)
 							   << " epath=" << path.toString();
 
-		MessageRouterRequest request{service, path, data};
+		MessageRouterRequest request{service, path, data, _use_8_bit_path_segments};
 
 		CommonPacketItemFactory commonPacketItemFactory;
 		CommonPacket commonPacket;

--- a/src/MessageRouter.h
+++ b/src/MessageRouter.h
@@ -22,10 +22,12 @@ namespace eipScanner {
 	public:
 		using SPtr = std::shared_ptr<MessageRouter>;
 
+        static constexpr bool USE_8_BIT_PATH_SEGMENTS = true;
+
 		/**
 		 * @brief Default constructor
 		 */
-		MessageRouter();
+		MessageRouter(bool use_8_bit_path_segments=false);
 
 		/**
 		 * @brief Default destructor
@@ -72,6 +74,8 @@ namespace eipScanner {
 		virtual cip::MessageRouterResponse sendRequest(SessionInfoIf::SPtr si, cip::CipUsint service,
 													   const cip::EPath& path) const;
 
+    private:
+        bool _use_8_bit_path_segments;
 	};
 }
 

--- a/src/cip/EPath.cpp
+++ b/src/cip/EPath.cpp
@@ -49,23 +49,45 @@ namespace cip {
 			, _size{3} {
 	}
 
-	std::vector<uint8_t> EPath::packPaddedPath() const {
-		Buffer buffer(_size*4);
+	std::vector<uint8_t> EPath::packPaddedPath(bool use_8_bit_path_segments) const {
+        if (use_8_bit_path_segments)
+        {
+            Buffer buffer(_size*2);
 
-		auto classSegment = static_cast<CipUint>(EPathSegmentTypes::CLASS_16_BITS);
-		buffer << classSegment << _classId;
+            auto classSegment = static_cast<CipUsint>(EPathSegmentTypes::CLASS_8_BITS);
+            buffer << classSegment << static_cast<CipUsint>(_classId);
 
-		if (_size > 1) {
-			auto instanceSegment = static_cast<CipUint>(EPathSegmentTypes::INSTANCE_16_BITS);
-			buffer << instanceSegment << _objectId;
+            if (_size > 1) {
+                auto instanceSegment = static_cast<CipUsint>(EPathSegmentTypes::INSTANCE_8_BITS);
+                buffer << instanceSegment << static_cast<CipUsint>(_objectId);
 
-			if (_size > 2) {
-				auto attributeSegment = static_cast<CipUint>(EPathSegmentTypes::ATTRIBUTE_16_BITS);
-				buffer << attributeSegment << _attributeId;
-			}
-		}
+                if (_size > 2) {
+                    auto attributeSegment = static_cast<CipUsint>(EPathSegmentTypes::ATTRIBUTE_8_BITS);
+                    buffer << attributeSegment << static_cast<CipUsint>(_attributeId);
+                }
+            }
 
-		return buffer.data();
+            return buffer.data();            
+        }
+        else
+        {
+            Buffer buffer(_size*4);
+
+            auto classSegment = static_cast<CipUint>(EPathSegmentTypes::CLASS_16_BITS);
+            buffer << classSegment << _classId;
+
+            if (_size > 1) {
+                auto instanceSegment = static_cast<CipUint>(EPathSegmentTypes::INSTANCE_16_BITS);
+                buffer << instanceSegment << _objectId;
+
+                if (_size > 2) {
+                    auto attributeSegment = static_cast<CipUint>(EPathSegmentTypes::ATTRIBUTE_16_BITS);
+                    buffer << attributeSegment << _attributeId;
+                }
+            }
+
+            return buffer.data();
+        }
 	}
 
 	CipUint EPath::getClassId() const {

--- a/src/cip/EPath.cpp
+++ b/src/cip/EPath.cpp
@@ -103,7 +103,12 @@ namespace cip {
 	}
 
 	CipUsint EPath::getSizeInWords() const {
-		return _size*2;
+        if (use_8_bit_path_segments) {
+            return _size;
+        }
+        else {
+    		return _size*2;
+		}
 	}
 
 	std::string EPath::toString() const {

--- a/src/cip/EPath.cpp
+++ b/src/cip/EPath.cpp
@@ -102,7 +102,7 @@ namespace cip {
 		return _attributeId;
 	}
 
-	CipUsint EPath::getSizeInWords() const {
+	CipUsint EPath::getSizeInWords(bool use_8_bit_path_segments) const {
         if (use_8_bit_path_segments) {
             return _size;
         }

--- a/src/cip/EPath.h
+++ b/src/cip/EPath.h
@@ -25,7 +25,7 @@ namespace cip {
 		CipUint getClassId() const;
 		CipUint getObjectId() const;
 		CipUint getAttributeId() const;
-		CipUsint getSizeInWords() const;
+		CipUsint getSizeInWords(bool use_8_bit_path_segments=false) const;
 
 		std::string toString() const;
 		bool operator==(const EPath& other) const;

--- a/src/cip/EPath.h
+++ b/src/cip/EPath.h
@@ -19,7 +19,7 @@ namespace cip {
 		explicit EPath(CipUint classId);
 		EPath(CipUint classId, CipUint objectId);
 		EPath(CipUint classId, CipUint objectId, CipUint attributeId);
-		std::vector<uint8_t> packPaddedPath() const;
+		std::vector<uint8_t> packPaddedPath(bool use_8_bit_path_segments=false) const;
 		void expandPaddedPath(const std::vector<uint8_t>& data);
 
 		CipUint getClassId() const;

--- a/src/cip/MessageRouterRequest.cpp
+++ b/src/cip/MessageRouterRequest.cpp
@@ -11,10 +11,11 @@ namespace cip {
 	using utils::Buffer;
 
 	MessageRouterRequest::MessageRouterRequest(CipUsint serviceCode,
-			const EPath& ePath, const std::vector<uint8_t> data)
+			const EPath& ePath, const std::vector<uint8_t> data, bool use_8_bit_path_segments)
 			: _serviceCode{serviceCode}
 			, _ePath{ePath}
-			, _data(data) {
+			, _data(data)
+            , _use_8_bit_path_segments(use_8_bit_path_segments) {
 	}
 
 	MessageRouterRequest::~MessageRouterRequest() = default;
@@ -23,7 +24,7 @@ namespace cip {
 		Buffer buffer;
 		buffer << _serviceCode
 			<< _ePath.getSizeInWords()
-			<< _ePath.packPaddedPath()
+			<< _ePath.packPaddedPath(_use_8_bit_path_segments)
 			<< _data;
 
 		return buffer.data();

--- a/src/cip/MessageRouterRequest.cpp
+++ b/src/cip/MessageRouterRequest.cpp
@@ -23,7 +23,7 @@ namespace cip {
 	std::vector<uint8_t> MessageRouterRequest::pack() const {
 		Buffer buffer;
 		buffer << _serviceCode
-			<< _ePath.getSizeInWords()
+			<< _ePath.getSizeInWords(_use_8_bit_path_segments)
 			<< _ePath.packPaddedPath(_use_8_bit_path_segments)
 			<< _data;
 

--- a/src/cip/MessageRouterRequest.h
+++ b/src/cip/MessageRouterRequest.h
@@ -15,7 +15,7 @@ namespace eipScanner {
 namespace cip {
 	class MessageRouterRequest {
 	public:
-		MessageRouterRequest(CipUsint serviceCode, const EPath& ePath, const std::vector<uint8_t> data);
+		MessageRouterRequest(CipUsint serviceCode, const EPath& ePath, const std::vector<uint8_t> data, bool use_8_bit_path_segments=false);
 		~MessageRouterRequest();
 
 		std::vector<uint8_t> pack() const;
@@ -23,6 +23,7 @@ namespace cip {
 		CipUsint _serviceCode;
 		EPath _ePath;
 		std::vector<uint8_t> _data;
+        bool _use_8_bit_path_segments;
 	};
 
 }


### PR DESCRIPTION
There are EthernetIP devices that do not support 16 bit path segments. The library does not support selecting the path segments width. In this pullrequest this is addressed.

A `MessageRouter` object can now be supplied a flag during construction that indicates that 8 bit path segments should be used. This `MessageRouter` can then be passed to the `ConnectionManager` and all `EPath`s will be converted to 8 bit path segments when a request is being composed.
