### PR TITLE
Fix CipString test by testing for regression since aa87de0

### DIFF
--- a/test/cip/TestCipString.cpp
+++ b/test/cip/TestCipString.cpp
@@ -11,9 +11,11 @@ using eipScanner::cip::CipBaseString;
 using eipScanner::utils::Buffer;
 
 TEST(TestCipString, ShuoldConvertToStdString) {
-	CipBaseString<uint8_t> cipString("Hello!");
+	std::string std_string("Hello!");
 
-	EXPECT_EQ("Hello!", cipString.toStdString());
+	CipBaseString<uint8_t> cipString(std_string);
+
+	EXPECT_EQ(std_string, cipString.toStdString());
 }
 
 TEST(TestCipString, ShuoldDecodeAndEncodeByBuffer) {

--- a/test/cip/TestCipString.cpp
+++ b/test/cip/TestCipString.cpp
@@ -10,7 +10,7 @@
 using eipScanner::cip::CipBaseString;
 using eipScanner::utils::Buffer;
 
-TEST(TestCipString, ShuoldConvertToStdString) {
+TEST(TestCipString, ShouldConvertToStdString) {
 	std::string std_string("Hello!");
 
 	CipBaseString<uint8_t> cipString(std_string);
@@ -18,7 +18,7 @@ TEST(TestCipString, ShuoldConvertToStdString) {
 	EXPECT_EQ(std_string, cipString.toStdString());
 }
 
-TEST(TestCipString, ShuoldDecodeAndEncodeByBuffer) {
+TEST(TestCipString, ShouldDecodeAndEncodeByBuffer) {
 	CipBaseString<uint8_t> srcString("Hello!");
 	CipBaseString<uint8_t> dstString;
 


### PR DESCRIPTION
See also #70 and #73.

Also fixed some spelling mistakes in the test names.