### PR TITLE
DiscoveryManager: move macro and fix Windows test

### DIFF
--- a/src/DiscoveryManager.cpp
+++ b/src/DiscoveryManager.cpp
@@ -10,13 +10,6 @@
 #include "utils/Buffer.h"
 
 #include "DiscoveryManager.h"
-#include "sockets/Platform.h"
-
-#if defined (__unix__) || defined(__APPLE__)
-#define DISCOVERY_SOCKET_RECEIVE_END_ERROR_CODE (EIPSCANNER_SOCKET_ERROR(EAGAIN))
-#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64)
-#define DISCOVERY_SOCKET_RECEIVE_END_ERROR_CODE (EIPSCANNER_SOCKET_ERROR(ETIMEDOUT))
-#endif
 
 namespace eipScanner {
 	using namespace cip;

--- a/src/DiscoveryManager.h
+++ b/src/DiscoveryManager.h
@@ -6,6 +6,13 @@
 #define EIPSCANNER_DISCOVERYMANAGER_H
 
 #include "IdentityObject.h"
+#include "sockets/Platform.h"
+
+#if defined (__unix__) || defined(__APPLE__)
+#define DISCOVERY_SOCKET_RECEIVE_END_ERROR_CODE (EIPSCANNER_SOCKET_ERROR(EAGAIN))
+#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64)
+#define DISCOVERY_SOCKET_RECEIVE_END_ERROR_CODE (EIPSCANNER_SOCKET_ERROR(ETIMEDOUT))
+#endif
 
 namespace eipScanner {
 

--- a/test/TestDiscoveryManager.cpp
+++ b/test/TestDiscoveryManager.cpp
@@ -61,14 +61,14 @@ public:
 	TMockSocket::SPtr _mockSocket;
 };
 
-TEST_F(TestDiscoveryManager, ShouldSendBroadcastMesasageAndGetResponses) {
+TEST_F(TestDiscoveryManager, ShouldSendBroadcastMessageAndGetResponses) {
 	TDiscoveryManager manager(_mockSocket);
 
 	EXPECT_CALL(*_mockSocket, Send(LIST_IDENTITY_REQUEST)).Times(1);
 	EXPECT_CALL(*_mockSocket, Receive(504))
 		.WillOnce(::testing::Return(LIST_IDENTITY_RESPONSE))
 		.WillOnce(::testing::Return(LIST_IDENTITY_RESPONSE))
-		.WillOnce(::testing::Throw(std::system_error(11, std::system_category())));
+		.WillOnce(::testing::Throw(std::system_error(DISCOVERY_SOCKET_RECEIVE_END_ERROR_CODE, std::system_category())));
 
 	auto devices = manager.discover();
 


### PR DESCRIPTION
The DiscoveryManager testcase mocks the Receive() function to throw an
exception, however, the error code is different on Windows vs Linux.
Thus, when running this test on Windows, it fails:

```
[----------] 1 test from TestDiscoveryManager
[ RUN      ] TestDiscoveryManager.ShouldSendBroadcastMesasageAndGetResponses
unknown file: Failure
C++ exception with description "Resource temporarily unavailable" thrown in the test body.
unknown file: Failure
C++ exception with description "Resource temporarily unavailable" thrown in the test body.
[  FAILED  ] TestDiscoveryManager.ShouldSendBroadcastMesasageAndGetResponses (2 ms)
[----------] 1 test from TestDiscoveryManager (2 ms total)
```

The difference in error codes between Windows and Linux has been
accounted for in the DiscoveryManager itself since 5c0cd06, but the
test was still broken on Windows.

Also fixed a spelling mistake.