### PR TITLE
CMakeLists: Fix compilation with GCC < 10 on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,14 @@ option(ENABLE_VENDOR_SRC "Enable vendor source" ON)
 option(TEST_ENABLED "Enable unit test" OFF)
 option(EXAMPLE_ENABLED "Build examples" OFF)
 
-# Prevent std::numeric_limits::max collision
-if (MSVC)
-	add_compile_definitions(NOMINMAX)
+if (WIN32)
+	# Needed on MinGW with GCC 10 or lower
+	add_compile_definitions(_WIN32_WINNT=0x0600)
+
+	# Prevent std::numeric_limits::max collision
+	if (MSVC)
+		add_compile_definitions(NOMINMAX)
+	endif()
 endif()
 
 add_subdirectory(src)


### PR DESCRIPTION
Some winsock2 functions needs at least _WIN32_WINNT=0x0600 defined.
This was discovered when using MinGW-w64 to cross-compile:

```make
[ 21%] Building CXX object src/CMakeFiles/EIPScannerS.dir/sockets/EndPoint.cpp.obj
/EIPScanner/src/sockets/EndPoint.cpp: In constructor ‘eipScanner::sockets::EndPoint::EndPoint(std::string, int)’:
/EIPScanner/src/sockets/EndPoint.cpp:38:9: error: ‘inet_pton’ was not declared in this scope; did you mean ‘inet_ntoa’?
   38 |     if (inet_pton(AF_INET, _host.c_str(), &_addr.sin_addr.s_addr) < 0) {
      |         ^~~~~~~~~
      |         inet_ntoa
gmake[2]: *** [src/CMakeFiles/EIPScannerS.dir/build.make:377: src/CMakeFiles/EIPScannerS.dir/sockets/EndPoint.cpp.obj] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:168: src/CMakeFiles/EIPScannerS.dir/all] Error 2
gmake: *** [Makefile:149: all] Error 2
```