### PR TITLE
Add option to use 8 bit segments

### DIFF
--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -34,8 +34,8 @@ namespace eipScanner {
 		FORWARD_CLOSE = 0x4E
 	};
 
-	ConnectionManager::ConnectionManager()
-		: ConnectionManager(std::make_shared<MessageRouter>()){
+	ConnectionManager::ConnectionManager(bool use_8_bit_path_segments)
+		: ConnectionManager(std::make_shared<MessageRouter>(use_8_bit_path_segments)){
 	}
 
 	ConnectionManager::ConnectionManager(const MessageRouter::SPtr& messageRouter)

--- a/src/ConnectionManager.h
+++ b/src/ConnectionManager.h
@@ -24,7 +24,7 @@ namespace eipScanner {
 		/**
 		 * @brief Default constructor
 		 */
-		ConnectionManager();
+		ConnectionManager(bool use_8_bit_path_segments=false);
 
 		/**
 		 * @note used fot testing


### PR DESCRIPTION
ConnectionManager passes through to the underlying MessageRouter.