### PR TITLE
fix: Leak in PowerFlex 525 process() functions

### DIFF
--- a/src/vendor/ra/powerFlex525/DPIFaultParameter.cpp
+++ b/src/vendor/ra/powerFlex525/DPIFaultParameter.cpp
@@ -114,42 +114,42 @@ namespace powerFlex525 {
 
 
 	static cip::CipLreal processVolts(uint16_t volts, int voltsParam) {
-		auto * parameterObject = new ParameterObject(voltsParam, true, 4);
+		ParameterObject parameterObject(voltsParam, true, 4);
 
-		parameterObject->setScalable(true);
-		parameterObject->setScalingMultiplier(1);
-		parameterObject->setScalingDivisor(1);
-		parameterObject->setScalingBase(1);
-		parameterObject->setScalingOffset(0);
-		parameterObject->setPrecision(0);
+		parameterObject.setScalable(true);
+		parameterObject.setScalingMultiplier(1);
+		parameterObject.setScalingDivisor(1);
+		parameterObject.setScalingBase(1);
+		parameterObject.setScalingOffset(0);
+		parameterObject.setPrecision(0);
 
-		return parameterObject->actualToEngValue(volts);
+		return parameterObject.actualToEngValue(volts);
 	}
 
 	static cip::CipLreal processCurrent(uint16_t current, int currentParam) {
-		auto * parameterObject = new ParameterObject(currentParam, true, 4);
+		ParameterObject parameterObject(currentParam, true, 4);
 
-		parameterObject->setScalable(true);
-		parameterObject->setScalingMultiplier(1);
-		parameterObject->setScalingDivisor(1);
-		parameterObject->setScalingBase(1);
-		parameterObject->setScalingOffset(0);
-		parameterObject->setPrecision(2);
+		parameterObject.setScalable(true);
+		parameterObject.setScalingMultiplier(1);
+		parameterObject.setScalingDivisor(1);
+		parameterObject.setScalingBase(1);
+		parameterObject.setScalingOffset(0);
+		parameterObject.setPrecision(2);
 
-		return parameterObject->actualToEngValue(current);
+		return parameterObject.actualToEngValue(current);
 	}
 
 	static cip::CipLreal processFrequency(uint16_t frequency, int frequencyParam) {
-		auto * parameterObject = new ParameterObject(frequencyParam, true, 4);
+		ParameterObject parameterObject(frequencyParam, true, 4);
 
-		parameterObject->setScalable(true);
-		parameterObject->setScalingMultiplier(1);
-		parameterObject->setScalingDivisor(1);
-		parameterObject->setScalingBase(1);
-		parameterObject->setScalingOffset(0);
-		parameterObject->setPrecision(2);
+		parameterObject.setScalable(true);
+		parameterObject.setScalingMultiplier(1);
+		parameterObject.setScalingDivisor(1);
+		parameterObject.setScalingBase(1);
+		parameterObject.setScalingOffset(0);
+		parameterObject.setPrecision(2);
 
-		return parameterObject->actualToEngValue(frequency);
+		return parameterObject.actualToEngValue(frequency);
 	}
 
 


### PR DESCRIPTION
As reported by LeakSanitizer:

```
Direct leak of 496 byte(s) in 2 object(s) allocated from:
    !0 0x7f3e31ed31c7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    !1 0x7f3e31df2612 in processCurrent /EIPScanner/src/vendor/ra/powerFlex525/DPIFaultParameter.cpp:130

Direct leak of 248 byte(s) in 1 object(s) allocated from:
    !0 0x7f3e31ed31c7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    !1 0x7f3e31df3b56 in processVolts /EIPScanner/src/vendor/ra/powerFlex525/DPIFaultParameter.cpp:117
    !2 0x7f3e31df3b56 in eipScanner::vendor::ra::powerFlex525::DPIFaultParameter::DPIFaultParameter(std::shared_ptr<eipScanner::SessionInfoIf> const&, std::shared_ptr<eipScanner::MessageRouter> const&, int, bool) /EIPScanner/src/vendor/ra/powerFlex525/DPIFaultParameter.cpp:274
```

While LeakSanitizer only reports `processVolts` and `processCurrents`, the `processFrequency` function also leaks in the same way.