### PR TITLE
Use enable_testing() in toplevel CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,6 @@ if (EXAMPLE_ENABLED)
 endif()
 
 if (TEST_ENABLED)
+    enable_testing()
     add_subdirectory(test)
 endif()
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,3 @@
-enable_testing()
 include_directories("${CMAKE_SOURCE_DIR}/src")
 include_directories("${CMAKE_SOURCE_DIR}/test")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")


### PR DESCRIPTION
This allows for using ctest (-V) for running the testsuite, instead of
manually calling the test executable.

enable_testing() should be in the toplevel CMakeLists.txt, according to
the documentation [1].

[1]. https://cmake.org/cmake/help/latest/command/enable_testing.html