### PR TITLE
Avoid building both a shared and static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ option(ENABLE_VENDOR_SRC "Enable vendor source" ON)
 option(TEST_ENABLED "Enable unit test" OFF)
 option(EXAMPLE_ENABLED "Build examples" OFF)
 
+if (DEFINED "${PROJECT_NAME}_SHARED_LIBS")
+    set(BUILD_SHARED_LIBS "${${PROJECT_NAME}_SHARED_LIBS}")
+endif()
+
 if (WIN32)
 	# Needed on MinGW with GCC 10 or lower
 	add_compile_definitions(_WIN32_WINNT=0x0600)

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -22,6 +22,13 @@ In order to compile and install the library, type from the project's root direct
    cmake ..
    cmake --build . --target install
 
+By default, this will build a static library. If a shared library is desired, add the following CMake option:
+
+::
+
+   cmake -DEIPScanner_SHARED_LIBS=ON ..
+
+
 Optionally, you can build the usage examples and the unit tests by adding the following CMake options:
 
 ::
@@ -56,7 +63,7 @@ First of all, we should create *CMakeLists.txt* with the following content:
 Pay attention to the last two lines. Currently, **EIPScanner** doesn't provide a cmake module to help to find
 the library on your machine and we have to do all manually. First, we point on the include directory whose path
 should be `path/were/eipscanner/is/installed/` + `EIPScanner`. Second, we link our executable file with the library 
-`EIPScanner`. If you'd like to use the static library instead, use `EIPScannerS` name.
+`EIPScanner`.
 
 Okay, we have *CMakeLists.txt*. Now we should create *main.cpp* and place there this code:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,12 +50,10 @@ if(ENABLE_VENDOR_SRC)
 	add_subdirectory(vendor)
 endif()
 
-add_library(EIPScanner SHARED ${SOURCE_FILES} ${VENDOR_FILES})
-add_library(EIPScannerS STATIC ${SOURCE_FILES} ${VENDOR_FILES})
+add_library(EIPScanner ${SOURCE_FILES} ${VENDOR_FILES})
 
 if(WIN32)
 	target_link_libraries(EIPScanner ws2_32)
-	target_link_libraries(EIPScannerS ws2_32)
 endif()
 
 set_target_properties(
@@ -64,7 +62,7 @@ set_target_properties(
         VERSION ${EIPSCANNER_FULL_VERSION}
         SOVERSION ${EIPSCANNER_MAJOR_VERSION})
 
-install(TARGETS EIPScanner EIPScannerS
+install(TARGETS EIPScanner
         LIBRARY
             DESTINATION lib
         ARCHIVE


### PR DESCRIPTION
There is no reason to unconditionally build both variants. It increases
compile times, and consumers already know whether or not they want a
static or shared artifact. Instead, use a standard CMake construct to
build either one of them.

To allow users to override static vs shared for EIPScanner only, use a
new variable called EIPScanner_SHARED_LIBS: If set, our add_library()
will create a shared library, if not, a static library is created.
Building a static library by default also matches the default behaviour
of add_library().

This still allows users to specify BUILD_SHARED_LIBS on the command line
as an ultimate override, but at the same time avoids having
BUILD_SHARED_LIBS be the only option for building static vs shared.