### PR TITLE
CMake: Accommodate using add_subdirectory()

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories("${CMAKE_SOURCE_DIR}/src")
+include_directories("${PROJECT_SOURCE_DIR}/src")
 
 add_executable(explicit_messaging ExplicitMessagingExample.cpp)
 target_link_libraries(explicit_messaging EIPScanner)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${CMAKE_CURRENT_LIST_DIR})
 
 set(SOURCE_FILES
         cip/connectionManager/ForwardCloseRequest.cpp
@@ -70,6 +70,6 @@ install(TARGETS EIPScanner EIPScannerS
         ARCHIVE
             DESTINATION lib)
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/
         DESTINATION include/EIPScanner
         FILES_MATCHING PATTERN "*.h*")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 enable_testing()
-include_directories("${CMAKE_SOURCE_DIR}/src")
-include_directories("${CMAKE_SOURCE_DIR}/test")
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+include_directories("${PROJECT_SOURCE_DIR}/src")
+include_directories("${PROJECT_SOURCE_DIR}/test")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
 find_package(GTest REQUIRED)
 find_package(GMock REQUIRED)


### PR DESCRIPTION
When the library is included in other projects with add_subdirectory(),
CMAKE_SOURCE_DIR does not point to our root anymore, but that of the
superbuild. This causes incorrect include directories.

To fix this, use CMAKE_CURRENT_LIST_DIR, which always points to
EIPScanner-root/src.

For consistency, purge the remaining usage of CMAKE_SOURCE_DIR.
PROJECT_SOURCE_DIR always points to the EIPScanner-root.