### PR TITLE
Prevent SIGPIPE signal when writing to closed socket

### DIFF
--- a/src/sockets/TCPSocket.cpp
+++ b/src/sockets/TCPSocket.cpp
@@ -36,6 +36,13 @@ namespace eipScanner {
 				throw std::system_error(BaseSocket::getLastError(), BaseSocket::getErrorCategory());
 			}
 
+#ifdef SO_NOSIGPIPE
+			// Do not generate SIGPIPE for this socket
+			if (setsockopt(_sockedFd, SOL_SOCKET, SO_NOSIGPIPE, &(int){ 1 }, sizeof(int)) < 0) {
+				throw std::system_error(BaseSocket::getLastError(), BaseSocket::getErrorCategory());
+			}
+#endif
+
 			// Set non-blocking
 #if defined(__unix__) || defined(__APPLE__)
 			auto arg = fcntl(_sockedFd, F_GETFL, NULL);

--- a/src/sockets/TCPSocket.cpp
+++ b/src/sockets/TCPSocket.cpp
@@ -120,7 +120,12 @@ namespace eipScanner {
 		void TCPSocket::Send(const std::vector<uint8_t> &data) const {
 			Logger(LogLevel::TRACE) << "Send " << data.size() << " bytes from TCP socket #" << _sockedFd << ".";
 
-			int count = send(_sockedFd, (char*)data.data(), data.size(), 0);
+			int flags = 0;
+#ifdef MSG_NOSIGNAL
+			// Do not generate SIGPIPE when calling send() on closed socket
+			flags |= MSG_NOSIGNAL;
+#endif
+			int count = send(_sockedFd, (char*)data.data(), data.size(), flags);
 			if (count < data.size()) {
 				throw std::system_error(BaseSocket::getLastError(), BaseSocket::getErrorCategory());
 			}

--- a/src/sockets/UDPSocket.cpp
+++ b/src/sockets/UDPSocket.cpp
@@ -46,8 +46,13 @@ namespace sockets {
 	void UDPSocket::Send(const std::vector <uint8_t> &data) const {
 		Logger(LogLevel::TRACE) << "Send " << data.size() << " bytes from UDP socket #" << _sockedFd << ".";
 
+		int flags = 0;
+#ifdef MSG_NOSIGNAL
+		// Do not generate SIGPIPE when calling send() on closed socket
+		flags |= MSG_NOSIGNAL;
+#endif
 		auto addr = _remoteEndPoint.getAddr();
-		int count = sendto(_sockedFd, (char*)data.data(), data.size(), 0,
+		int count = sendto(_sockedFd, (char*)data.data(), data.size(), flags,
 				(struct sockaddr *)&addr, sizeof(addr));
 		if (count < data.size()) {
 			throw std::system_error(BaseSocket::getLastError(), BaseSocket::getErrorCategory());

--- a/src/sockets/UDPSocket.cpp
+++ b/src/sockets/UDPSocket.cpp
@@ -34,6 +34,13 @@ namespace sockets {
 			throw std::system_error(BaseSocket::getLastError(), BaseSocket::getErrorCategory());
 		}
 
+#ifdef SO_NOSIGPIPE
+		// Do not generate SIGPIPE for this socket
+		if (setsockopt(_sockedFd, SOL_SOCKET, SO_NOSIGPIPE, &(int){ 1 }, sizeof(int)) < 0) {
+			throw std::system_error(BaseSocket::getLastError(), BaseSocket::getErrorCategory());
+		}
+#endif
+
 		Logger(LogLevel::DEBUG) << "Opened UDP socket fd=" << _sockedFd;
 	}
 


### PR DESCRIPTION
By default, `SIGPIPE` will terminate the complete process. This is obviously not the ideal way to handle writing a closed socket. We already propagate `EPIPE` using the `throw std::system_error`. So, signal to the OS not to generate a signal.

The other option would be to install a signal handler for `SIGPIPE`, but that is not ideal inside a library.