### PR TITLE
TCPSocket: handle EINTR error

### DIFF
--- a/src/sockets/TCPSocket.cpp
+++ b/src/sockets/TCPSocket.cpp
@@ -144,11 +144,16 @@ namespace eipScanner {
 			int count = 0;
 			while (size > count) {
 				auto len = recv(_sockedFd, (char*)(recvBuffer.data() + count), size - count, 0);
-				Logger(LogLevel::TRACE) << "Received " << len << " bytes from TCP socket #" << _sockedFd << ".";
-				count += len;
 				if (len < 0) {
+					// Check for EINTR, in which case, better luck next time
+					if (BaseSocket::getLastError() == EIPSCANNER_SOCKET_ERROR(EINTR)) {
+						continue;
+					}
 					throw std::system_error(BaseSocket::getLastError(), BaseSocket::getErrorCategory());
 				}
+
+				Logger(LogLevel::TRACE) << "Received " << len << " bytes from TCP socket #" << _sockedFd << ".";
+				count += len;
 
 				if (len == 0) {
 					break;


### PR DESCRIPTION
This error is non-fatal and should be handled by retrying.

With this, the error handling is moved before the logging and addition of the count variable. In case of error, len would be -1 on !windows, so it would add a negative value.

Errors other than EINTR are thrown as usual.