### PR TITLE
Use virtual destructor for SessionInfoIf

### DIFF
--- a/src/SessionInfoIf.h
+++ b/src/SessionInfoIf.h
@@ -19,6 +19,8 @@ namespace eipScanner {
 	public:
 		using SPtr = std::shared_ptr<SessionInfoIf>;
 
+		virtual ~SessionInfoIf(){}
+
 		/**
 		 * Sends and receives EIP Encapsulation packet
 		 * @param packet the EIP Encapsulation packet to send


### PR DESCRIPTION
SessionInfoIf is ment to be a base class for polymorphic types. As such it should have a virtual destructor. This is so that objects that are descendants of it will properly call destructors of thier parent classes. Without this resource leaks can easily occur.