### PR TITLE
Add the option to set the port used by the originiator for implicit communication.

### DIFF
--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -145,13 +145,13 @@ namespace eipScanner {
 				}
 
 			} else {
-				ioConnection->_socket = std::make_unique<UDPSocket>(si->getRemoteEndPoint().getHost(), EIP_DEFAULT_IMPLICIT_PORT);
+				ioConnection->_socket = std::make_unique<UDPSocket>(si->getRemoteEndPoint().getHost(), _messageRouter->implicitPort());
 			}
 
 			Logger(LogLevel::INFO) << "Open UDP socket to send data to "
 					<< ioConnection->_socket->getRemoteEndPoint().toString();
 
-			findOrCreateSocket(sockets::EndPoint(si->getRemoteEndPoint().getHost(), EIP_DEFAULT_IMPLICIT_PORT));
+			findOrCreateSocket(sockets::EndPoint(si->getRemoteEndPoint().getHost(), _messageRouter->implicitPort()));
 
 			auto result = _connectionMap
 					.insert(std::make_pair(response.getT2ONetworkConnectionId(), ioConnection));

--- a/src/ConnectionManager.h
+++ b/src/ConnectionManager.h
@@ -44,7 +44,7 @@ namespace eipScanner {
 		 * @param isLarge use large forward open if true
 		 * @return weak pointer to the created connection or nullptr if got an error
 		 */
-		IOConnection::WPtr forwardOpen(const SessionInfoIf::SPtr& si, cip::connectionManager::ConnectionParameters connectionParameters, bool isLarge = false);
+		IOConnection::WPtr forwardOpen(const SessionInfoIf::SPtr& si, cip::connectionManager::ConnectionParameters connectionParameters, bool isLarge = false, cip::CipUint implicit_port=EIP_DEFAULT_IMPLICIT_PORT);
 
 		/**
 		 * @brief Opens an EIP IO connection with the EIP adapter

--- a/src/MessageRouter.cpp
+++ b/src/MessageRouter.cpp
@@ -22,8 +22,8 @@ namespace eipScanner {
 	using eip::EncapsPacket;
 	using eip::EncapsPacketFactory;
 
-	MessageRouter::MessageRouter(bool use_8_bit_path_segments, cip::CipUint implicit_port)
-    : _use_8_bit_path_segments(use_8_bit_path_segments), _implicit_port(implicit_port)
+	MessageRouter::MessageRouter(bool use_8_bit_path_segments)
+    : _use_8_bit_path_segments(use_8_bit_path_segments)
     {};
 
 	MessageRouter::~MessageRouter() = default;
@@ -47,7 +47,7 @@ namespace eipScanner {
 
 		CommonPacketItemFactory commonPacketItemFactory;
 		CommonPacket commonPacket;
-        commonPacket << commonPacketItemFactory.createT2OSockaddrInfo(_implicit_port, 0);
+        commonPacket << commonPacketItemFactory.createNullAddressItem();
 		commonPacket << commonPacketItemFactory.createUnconnectedDataItem(request.pack());
 
 		for(auto& item : additionalPacketItems) {
@@ -85,8 +85,4 @@ namespace eipScanner {
 		return this->sendRequest(si, service, path, {}, {});
 	}
 
-    cip::CipUint
-    MessageRouter::implicitPort() const {
-        return _implicit_port;
-    }
 }

--- a/src/MessageRouter.cpp
+++ b/src/MessageRouter.cpp
@@ -22,8 +22,8 @@ namespace eipScanner {
 	using eip::EncapsPacket;
 	using eip::EncapsPacketFactory;
 
-	MessageRouter::MessageRouter(bool use_8_bit_path_segments) 
-    : _use_8_bit_path_segments(use_8_bit_path_segments)
+	MessageRouter::MessageRouter(bool use_8_bit_path_segments, cip::CipUint implicit_port)
+    : _use_8_bit_path_segments(use_8_bit_path_segments), _implicit_port(implicit_port)
     {};
 
 	MessageRouter::~MessageRouter() = default;
@@ -47,7 +47,7 @@ namespace eipScanner {
 
 		CommonPacketItemFactory commonPacketItemFactory;
 		CommonPacket commonPacket;
-		commonPacket << commonPacketItemFactory.createNullAddressItem();
+        commonPacket << commonPacketItemFactory.createT2OSockaddrInfo(_implicit_port, 0);
 		commonPacket << commonPacketItemFactory.createUnconnectedDataItem(request.pack());
 
 		for(auto& item : additionalPacketItems) {
@@ -84,4 +84,9 @@ namespace eipScanner {
 	MessageRouter::sendRequest(SessionInfoIf::SPtr si, CipUsint service, const EPath &path) const {
 		return this->sendRequest(si, service, path, {}, {});
 	}
+
+    cip::CipUint
+    MessageRouter::implicitPort() const {
+        return _implicit_port;
+    }
 }

--- a/src/MessageRouter.h
+++ b/src/MessageRouter.h
@@ -27,9 +27,7 @@ namespace eipScanner {
 		/**
 		 * @brief Default constructor
 		 */
-		MessageRouter(bool use_8_bit_path_segments=false, cip::CipUint implicit_port=EIP_DEFAULT_IMPLICIT_PORT);
-		MessageRouter(cip::CipUint implicit_port) : MessageRouter(false, implicit_port){ };
-		MessageRouter(bool use_8_bit_path_segments) : MessageRouter(use_8_bit_path_segments, EIP_DEFAULT_IMPLICIT_PORT) {};
+		MessageRouter(bool use_8_bit_path_segments=false);
 
 		/**
 		 * @brief Default destructor
@@ -76,11 +74,8 @@ namespace eipScanner {
 		virtual cip::MessageRouterResponse sendRequest(SessionInfoIf::SPtr si, cip::CipUsint service,
 													   const cip::EPath& path) const;
 
-        cip::CipUint implicitPort() const;
-
     private:
         bool _use_8_bit_path_segments;
-        cip::CipUint _implicit_port;
 	};
 }
 

--- a/src/MessageRouter.h
+++ b/src/MessageRouter.h
@@ -27,7 +27,9 @@ namespace eipScanner {
 		/**
 		 * @brief Default constructor
 		 */
-		MessageRouter(bool use_8_bit_path_segments=false);
+		MessageRouter(bool use_8_bit_path_segments=false, cip::CipUint implicit_port=EIP_DEFAULT_IMPLICIT_PORT);
+		MessageRouter(cip::CipUint implicit_port) : MessageRouter(false, implicit_port){ };
+		MessageRouter(bool use_8_bit_path_segments) : MessageRouter(use_8_bit_path_segments, EIP_DEFAULT_IMPLICIT_PORT) {};
 
 		/**
 		 * @brief Default destructor
@@ -74,8 +76,11 @@ namespace eipScanner {
 		virtual cip::MessageRouterResponse sendRequest(SessionInfoIf::SPtr si, cip::CipUsint service,
 													   const cip::EPath& path) const;
 
+        cip::CipUint implicitPort() const;
+
     private:
         bool _use_8_bit_path_segments;
+        cip::CipUint _implicit_port;
 	};
 }
 

--- a/src/eip/CommonPacketItemFactory.cpp
+++ b/src/eip/CommonPacketItemFactory.cpp
@@ -27,5 +27,11 @@ namespace eip {
 		buffer << connectionId << seqNumber;
 		return CommonPacketItem(CommonPacketItemIds::SEQUENCED_ADDRESS_ITEM, buffer.data());
 	}
+    CommonPacketItem
+    CommonPacketItemFactory::createT2OSockaddrInfo(cip::CipUint port, cip::CipUdint address) const {
+        Buffer buffer;
+        buffer << htons(cip::CipInt(2)) << htons(port) << htonl(address) << cip::CipUdint(0) << cip::CipUdint(0);
+        return CommonPacketItem(CommonPacketItemIds::T2O_SOCKADDR_INFO, buffer.data());
+    }
 }
 }

--- a/src/eip/CommonPacketItemFactory.h
+++ b/src/eip/CommonPacketItemFactory.h
@@ -17,6 +17,7 @@ namespace eip {
 		CommonPacketItem createUnconnectedDataItem(const std::vector<uint8_t> &data) const;
 		CommonPacketItem createSequenceAddressItem(cip::CipUdint connectionId, cip::CipUdint seqNumber) const;
 		CommonPacketItem createConnectedDataItem(const std::vector<uint8_t> &data) const;
+        CommonPacketItem createT2OSockaddrInfo(cip::CipUint port, cip::CipUdint address) const;
 	};
 }
 }


### PR DESCRIPTION
This allows multiple processes on one host to start implicit communication sessions by using different originator ports.