### PR TITLE
Drop C++ standard to C++17 and add multicast T2O support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,11 @@ project(EIPScanner
     HOMEPAGE_URL "https://github.com/nimbuscontrols/EIPScanner"
     )
 
-set(CMAKE_CXX_STANDARD 20)
+# C++17: the Luckfox/RV1106 SDK cross toolchain is GCC 8.3 (no C++20). The
+# codebase uses no C++20-only features, so this is a clean downgrade.
+# (A bare set() here would otherwise override -DCMAKE_CXX_STANDARD from buildroot.)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(ENABLE_VENDOR_SRC "Enable vendor source" ON)
 option(TEST_ENABLED "Enable unit test" OFF)
 option(EXAMPLE_ENABLED "Build examples" OFF)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Vendor specific objects:
 ## Requirements
 
 * CMake 3.5 and higher
-* C++20 compiler (tested with GCC and MinGW)
+* C++17 compiler (this fork: downgraded from upstream C++20 for the
+  Luckfox/RV1106 SDK toolchain, GCC 8.3 / uClibc-ng; no C++20-only features used)
 * Linux, MacOS, and Windows
 
 ## Installing

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -6,6 +6,13 @@
 #include <cstdlib>
 #include <random>
 
+#if defined(__unix__) || defined(__APPLE__)
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64)
+#include <ws2tcpip.h>
+#endif
+
 #include "ConnectionManager.h"
 #include "eip/CommonPacket.h"
 #include "cip/connectionManager/ForwardOpenRequest.h"
@@ -27,6 +34,12 @@ namespace eipScanner {
 	using sockets::UDPSocket;
 	using sockets::UDPBoundSocket;
 	using sockets::BaseSocket;
+
+	// IPv4 multicast range 224.0.0.0 .. 239.255.255.255 (class D).
+	static bool isMulticastAddr(const struct in_addr& a) {
+		uint32_t h = ntohl(a.s_addr);
+		return h >= 0xE0000000u && h <= 0xEFFFFFFFu;
+	}
 
 	enum class ConnectionManagerServiceCodes : cip::CipUsint {
 		FORWARD_OPEN = 0x54,
@@ -151,7 +164,27 @@ namespace eipScanner {
 			Logger(LogLevel::INFO) << "Open UDP socket to send data to "
 					<< ioConnection->_socket->getRemoteEndPoint().toString();
 
-			findOrCreateSocket(sockets::EndPoint(si->getRemoteEndPoint().getHost(), EIP_DEFAULT_IMPLICIT_PORT));
+			// Set up the T2O receive socket. If the target advertised a multicast
+			// T2O_SOCKADDR_INFO, join that group; otherwise receive unicast on the
+			// implicit port (legacy point-to-point behaviour).
+			auto t2oSockAddrInfo = std::find_if(additionalItems.begin(), additionalItems.end(),
+					[](auto item) { return item.getTypeId() == eip::CommonPacketItemIds::T2O_SOCKADDR_INFO; });
+
+			bool t2oMulticast = false;
+			if (t2oSockAddrInfo != additionalItems.end()) {
+				Buffer t2oSockAddrBuffer(t2oSockAddrInfo->getData());
+				sockets::EndPoint t2oEndPoint("", 0);
+				t2oSockAddrBuffer >> t2oEndPoint;
+
+				if (isMulticastAddr(t2oEndPoint.getAddr().sin_addr)) {
+					findOrCreateMulticastSocket(t2oEndPoint);
+					t2oMulticast = true;
+				}
+			}
+
+			if (!t2oMulticast) {
+				findOrCreateSocket(sockets::EndPoint(si->getRemoteEndPoint().getHost(), EIP_DEFAULT_IMPLICIT_PORT));
+			}
 
 			auto result = _connectionMap
 					.insert(std::make_pair(response.getT2ONetworkConnectionId(), ioConnection));
@@ -226,39 +259,55 @@ namespace eipScanner {
 		}
 	}
 
+	void ConnectionManager::attachIoReceiveHandler(const UDPBoundSocket::SPtr& socket) {
+		socket->setBeginReceiveHandler([this](BaseSocket& sock) {
+			auto recvData = sock.Receive(8192);
+			CommonPacket commonPacket;
+			commonPacket.expand(recvData);
+
+			// TODO: Check TypeIDs and sequence of the packages
+			Buffer buffer(commonPacket.getItems().at(0).getData());
+			cip::CipUdint connectionId;
+			buffer >> connectionId;
+			Logger(LogLevel::DEBUG) << "Received data from connection T2O_ID=" << connectionId;
+
+			auto io = _connectionMap.find(connectionId);
+			if (io != _connectionMap.end()) {
+				io->second->notifyReceiveData(commonPacket.getItems().at(1).getData());
+			} else {
+				Logger(LogLevel::ERROR) << "Received data from unknown connection T2O_ID=" << connectionId;
+			}
+		});
+	}
+
 	UDPBoundSocket::SPtr ConnectionManager::findOrCreateSocket(const sockets::EndPoint& endPoint) {
 		auto socket = _socketMap.find(endPoint);
 		if (socket == _socketMap.end()) {
 			auto newSocket = std::make_shared<UDPBoundSocket>(endPoint);
 			_socketMap[endPoint] = newSocket;
-			newSocket->setBeginReceiveHandler([](sockets::BaseSocket& sock) {
-			  (void) sock;
-				Logger(LogLevel::DEBUG) << "Received something";
-			});
-
-			newSocket->setBeginReceiveHandler([this](BaseSocket& sock) {
-				auto recvData = sock.Receive(8192);
-				CommonPacket commonPacket;
-				commonPacket.expand(recvData);
-
-				// TODO: Check TypeIDs and sequence of the packages
-				Buffer buffer(commonPacket.getItems().at(0).getData());
-				cip::CipUdint connectionId;
-				buffer >> connectionId;
-				Logger(LogLevel::DEBUG) << "Received data from connection T2O_ID=" << connectionId;
-
-				auto io = _connectionMap.find(connectionId);
-				if (io != _connectionMap.end()) {
-					io->second->notifyReceiveData(commonPacket.getItems().at(1).getData());
-				} else {
-					Logger(LogLevel::ERROR) << "Received data from unknown connection T2O_ID=" << connectionId;
-				}
-			});
-
+			attachIoReceiveHandler(newSocket);
 			return newSocket;
 		}
 
 		return socket->second;
+	}
+
+	// Receive T2O over a multicast group: bind the producer's port (INADDR_ANY)
+	// and join the group the target advertised in its T2O_SOCKADDR_INFO.
+	UDPBoundSocket::SPtr ConnectionManager::findOrCreateMulticastSocket(const sockets::EndPoint& groupEndPoint) {
+		auto socket = _socketMap.find(groupEndPoint);
+		if (socket != _socketMap.end()) {
+			return socket->second;
+		}
+
+		auto newSocket = std::make_shared<UDPBoundSocket>(groupEndPoint);
+		newSocket->joinMulticastGroup(groupEndPoint.getAddr().sin_addr);
+		_socketMap[groupEndPoint] = newSocket;
+		attachIoReceiveHandler(newSocket);
+
+		Logger(LogLevel::INFO) << "Joined multicast group " << groupEndPoint.toString()
+				<< " for T2O reception";
+		return newSocket;
 	}
 
 	bool ConnectionManager::hasOpenConnections() const {

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -300,7 +300,7 @@ namespace eipScanner {
 			return socket->second;
 		}
 
-		auto newSocket = std::make_shared<UDPBoundSocket>(groupEndPoint);
+		auto newSocket = std::make_shared<UDPBoundSocket>(groupEndPoint, /*bindToGroup=*/true);
 		newSocket->joinMulticastGroup(groupEndPoint.getAddr().sin_addr);
 		_socketMap[groupEndPoint] = newSocket;
 		attachIoReceiveHandler(newSocket);

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -298,9 +298,9 @@ namespace eipScanner {
 		return socket->second;
 	}
 
-	// Receive T2O over a multicast group: bind the producer's port (INADDR_ANY)
-	// and join the group the target advertised in its T2O_SOCKADDR_INFO.
-	UDPBoundSocket::SPtr ConnectionManager::findOrCreateMulticastSocket(const sockets::EndPoint& groupEndPoint) {
+	// Receive T2O over a multicast group: bind to the group address/port
+	// (to avoid capturing unicast datagrams on the same port) and join the group
+	// the target advertised in its T2O_SOCKADDR_INFO.
 		auto socket = _socketMap.find(groupEndPoint);
 		if (socket != _socketMap.end()) {
 			return socket->second;

--- a/src/ConnectionManager.cpp
+++ b/src/ConnectionManager.cpp
@@ -265,15 +265,21 @@ namespace eipScanner {
 			CommonPacket commonPacket;
 			commonPacket.expand(recvData);
 
+			const auto& items = commonPacket.getItems();
+			if (items.size() < 2) {
+				Logger(LogLevel::WARNING) << "Received malformed I/O CommonPacket: expected >=2 items, got " << items.size();
+				return;
+			}
+
 			// TODO: Check TypeIDs and sequence of the packages
-			Buffer buffer(commonPacket.getItems().at(0).getData());
+			Buffer buffer(items[0].getData());
 			cip::CipUdint connectionId;
 			buffer >> connectionId;
 			Logger(LogLevel::DEBUG) << "Received data from connection T2O_ID=" << connectionId;
 
 			auto io = _connectionMap.find(connectionId);
 			if (io != _connectionMap.end()) {
-				io->second->notifyReceiveData(commonPacket.getItems().at(1).getData());
+				io->second->notifyReceiveData(items[1].getData());
 			} else {
 				Logger(LogLevel::ERROR) << "Received data from unknown connection T2O_ID=" << connectionId;
 			}

--- a/src/ConnectionManager.h
+++ b/src/ConnectionManager.h
@@ -79,6 +79,8 @@ namespace eipScanner {
 		std::map<sockets::EndPoint, std::shared_ptr<sockets::UDPBoundSocket>> _socketMap;
 
 		sockets::UDPBoundSocket::SPtr  findOrCreateSocket(const sockets::EndPoint& endPoint);
+		sockets::UDPBoundSocket::SPtr  findOrCreateMulticastSocket(const sockets::EndPoint& groupEndPoint);
+		void attachIoReceiveHandler(const sockets::UDPBoundSocket::SPtr& socket);
 		cip::CipUint _incarnationId;
 	};
 }

--- a/src/sockets/UDPBoundSocket.cpp
+++ b/src/sockets/UDPBoundSocket.cpp
@@ -22,7 +22,7 @@ namespace sockets {
 		: UDPBoundSocket(EndPoint(host, port)) {
 
 	}
-	UDPBoundSocket::UDPBoundSocket(EndPoint endPoint)
+	UDPBoundSocket::UDPBoundSocket(EndPoint endPoint, bool bindToGroup)
 		: UDPSocket(std::move(endPoint)) {
 		int on = 1;
 		if (setsockopt(_sockedFd, SOL_SOCKET, SO_REUSEADDR, (char *) &on, sizeof(on)) < 0) {
@@ -30,7 +30,12 @@ namespace sockets {
 		}
 
 		auto addr = _remoteEndPoint.getAddr();
-		addr.sin_addr.s_addr = INADDR_ANY;
+		// Unicast: bind the port on any local address. Multicast: bind to the
+		// group address so the socket only receives that group (and does not
+		// steal unicast datagrams on the same port).
+		if (!bindToGroup) {
+			addr.sin_addr.s_addr = INADDR_ANY;
+		}
 		if (bind(_sockedFd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 			throw std::system_error(BaseSocket::getLastError(), BaseSocket::getErrorCategory());
 		}

--- a/src/sockets/UDPBoundSocket.cpp
+++ b/src/sockets/UDPBoundSocket.cpp
@@ -2,9 +2,14 @@
 // Created by Aleksey Timin on 11/21/19.
 //
 #include <system_error>
+#include <cstring>
 
-//#include <sys/socket.h>
-//#include <netinet/in.h>
+#if defined(__unix__) || defined(__APPLE__)
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#elif defined(_WIN32) || defined(WIN32) || defined(_WIN64)
+#include <ws2tcpip.h>
+#endif
 
 #include "UDPBoundSocket.h"
 #include "Platform.h"
@@ -31,6 +36,28 @@ namespace sockets {
 		}
 	}
 
-	sockets::UDPBoundSocket::~UDPBoundSocket() = default;
+	void UDPBoundSocket::joinMulticastGroup(const struct in_addr& group) {
+		struct ip_mreq mreq;
+		std::memset(&mreq, 0, sizeof(mreq));
+		mreq.imr_multiaddr = group;
+		mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+		if (setsockopt(_sockedFd, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+				(char *) &mreq, sizeof(mreq)) < 0) {
+			throw std::system_error(BaseSocket::getLastError(), BaseSocket::getErrorCategory());
+		}
+		_multicastGroup = group;
+		_joinedMulticast = true;
+	}
+
+	sockets::UDPBoundSocket::~UDPBoundSocket() {
+		if (_joinedMulticast) {
+			struct ip_mreq mreq;
+			std::memset(&mreq, 0, sizeof(mreq));
+			mreq.imr_multiaddr = _multicastGroup;
+			mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+			setsockopt(_sockedFd, IPPROTO_IP, IP_DROP_MEMBERSHIP,
+				(char *) &mreq, sizeof(mreq));
+		}
+	}
 }
 }

--- a/src/sockets/UDPBoundSocket.h
+++ b/src/sockets/UDPBoundSocket.h
@@ -22,6 +22,14 @@ namespace sockets {
 		explicit UDPBoundSocket(EndPoint endPoint);
 		UDPBoundSocket(std::string host, int port);
 		virtual ~UDPBoundSocket();
+
+		// Join an IPv4 multicast group on this bound socket so a target's
+		// T2O multicast producer is received. Dropped on destruction.
+		void joinMulticastGroup(const struct in_addr& group);
+
+	private:
+		struct in_addr _multicastGroup{};
+		bool _joinedMulticast = false;
 	};
 }
 }

--- a/src/sockets/UDPBoundSocket.h
+++ b/src/sockets/UDPBoundSocket.h
@@ -19,7 +19,10 @@ namespace sockets {
 		using WPtr = std::weak_ptr<UDPBoundSocket>;
 		using SPtr = std::shared_ptr<UDPBoundSocket>;
 
-		explicit UDPBoundSocket(EndPoint endPoint);
+		// bindToGroup=true binds to endPoint's address (a multicast group) so
+		// the socket only receives that group's datagrams; false binds
+		// INADDR_ANY (the legacy unicast-receive behaviour).
+		explicit UDPBoundSocket(EndPoint endPoint, bool bindToGroup = false);
 		UDPBoundSocket(std::string host, int port);
 		virtual ~UDPBoundSocket();
 


### PR DESCRIPTION
This pull request adds support for receiving I/O data over multicast UDP in addition to unicast, making the library compatible with EtherNet/IP devices that use multicast for T2O (Target-to-Originator) connections. The changes include detection of multicast addresses, correct socket binding and group joining, handler refactoring, and documentation updates. The C++ standard is also downgraded from C++20 to C++17 for compatibility with the Luckfox/RV1106 SDK toolchain.

**Multicast I/O support:**

* Added detection of multicast addresses and logic to join multicast groups for T2O (Target-to-Originator) I/O data, including new methods `findOrCreateMulticastSocket`, `attachIoReceiveHandler`, and the use of `joinMulticastGroup` in `ConnectionManager.cpp` and `UDPBoundSocket`. This allows the library to receive multicast I/O packets as required by some EtherNet/IP devices. [[1]](diffhunk://#diff-81c96b17ed0c158abcef7d1916e3e1f9c20260cbbabca3184b1cb201076b3d18R167-R187) [[2]](diffhunk://#diff-81c96b17ed0c158abcef7d1916e3e1f9c20260cbbabca3184b1cb201076b3d18L229-R318) [[3]](diffhunk://#diff-9c219b3f02251d59403849f0026af1534af7ed43f4d1669173afadbf585da280R82-R83) [[4]](diffhunk://#diff-6bc010167c2ca143380f8b62b50151502f434b193d2f558597d72a2f96ed6181L20-R66) [[5]](diffhunk://#diff-0d764f93ed2c94ca205e31a214422e263e0a2d1f8fd8f43fb62917f47875d75bL22-R35)

* Refactored socket receive handler logic to improve clarity and robustness, including checks for malformed packets and clearer separation of handler attachment.

**Platform and portability improvements:**

* Added platform-specific includes for socket headers to support both UNIX-like systems and Windows, improving cross-platform compatibility. [[1]](diffhunk://#diff-81c96b17ed0c158abcef7d1916e3e1f9c20260cbbabca3184b1cb201076b3d18R9-R15) [[2]](diffhunk://#diff-6bc010167c2ca143380f8b62b50151502f434b193d2f558597d72a2f96ed6181R5-R12)

**Build and documentation updates:**

* Downgraded the required C++ standard from C++20 to C++17 in `CMakeLists.txt` and updated the `README.md` to reflect this, ensuring compatibility with GCC 8.3 and the Luckfox/RV1106 SDK. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL14-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R30)